### PR TITLE
LPS-78854 Clean up SF list

### DIFF
--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -20,32 +20,9 @@
 		<check name="BNDBundleInformationCheck" />
 		<check name="BNDDirectoryNameCheck" />
 		<check name="BNDExportsCheck">
-			<property name="allowedExportPackageDirName" value="apio-architect-sample-liferay-portal" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-data-provider" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-expression" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-form-builder" />
 			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-form-evaluator" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-form-field-type" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-form-renderer" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-form-values-factory" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-form-values-query" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-io" />
 			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-service" />
-			<property name="allowedExportPackageDirName" value="dynamic-data-mapping-validator" />
-			<property name="allowedExportPackageDirName" value="journal-content-asset-addon-entry/journal-content-asset-addon-entry-common" />
-			<property name="allowedExportPackageDirName" value="journal-service" />
-			<property name="allowedExportPackageDirName" value="journal-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/collaboration/blogs/blogs-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/collaboration/bookmarks/bookmarks-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/collaboration/message-boards/message-boards-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/collaboration/microblogs/microblogs-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/collaboration/wiki/wiki-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/events-display/events-display-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/forms-and-workflow/calendar/calendar-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/alloy/alloy-mvc" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/frontend-editor/frontend-editor-lang" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/mobile-device-rules/mobile-device-rules-service" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/petra/petra-content" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/petra/petra-doulos" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/petra/petra-encryptor" />
@@ -57,43 +34,11 @@
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/petra/petra-salesforce-client" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/petra/petra-xml" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal/portal-dao-orm-custom-sql" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal/portal-instance-lifecycle" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal/portal-spring-extender" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal/portal-upgrade" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-cache/portal-cache" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-cache/portal-cache-ehcache" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-cache/portal-cache-ehcache-provider" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-cache/portal-cache-ehcache-spi" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-configuration/portal-configuration-upgrade-util" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-portlet-bridge/portal-portlet-bridge-soy" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-remote/portal-remote-soap-extender" />
 			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-search/portal-search-elasticsearch" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-search/portal-search-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-security/portal-security-auth-verifier" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-security/portal-security-auto-login" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-security/portal-security-ldap" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-security/portal-security-service-access-policy-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-security-sso/portal-security-sso-openid-connect" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-settings/portal-settings-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/portal-template/portal-template-soy" />
-			<property name="allowedExportPackageDirName" value="modules/apps/foundation/users-admin/users-admin-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/knowledge-base/knowledge-base-markdown-converter" />
-			<property name="allowedExportPackageDirName" value="modules/apps/knowledge-base/knowledge-base-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/mail-reader/mail-reader-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/portal-security-wedeploy-auth/portal-security-wedeploy-auth-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/push-notifications/push-notifications-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/shopping/shopping-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/static/" />
-			<property name="allowedExportPackageDirName" value="modules/apps/sync/sync-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/asset/asset-categories-admin-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/asset/asset-publisher-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/asset/asset-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/export-import/export-import-service" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/export-import/export-import-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/layout/layout-item-selector-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/portlet-display-template/portlet-display-template" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/product-navigation/product-navigation-product-menu-web" />
-			<property name="allowedExportPackageDirName" value="modules/apps/web-experience/rss/rss-util" />
+			<property name="allowedExportPackageDirName" value="modules/apps/static/osgi/osgi-util" />
 		</check>
 		<check name="BNDIncludeResourceCheck" />
 		<check name="BNDWebContextPathCheck" />


### PR DESCRIPTION
cc @shuyangzhou

Hi Peter, this pull removes some of the exceptions from BNDExportsCheck for master. As I understand, this should be the only change needed since [source-formatter.properties](https://github.com/liferay/liferay-portal-ee/blob/7.0.x/source-formatter.properties) in 7.0.x has the `override.bnd.exports.check.allowed.export.package.dir.name` property already, correct?