### PR TITLE
[TS] LPS-83365

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/KBArticleAssetRendererFactory.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/KBArticleAssetRendererFactory.java
@@ -66,7 +66,13 @@ public class KBArticleAssetRendererFactory
 		KBArticle kbArticle = getKBArticle(
 			classPK, WorkflowConstants.STATUS_ANY);
 
-		return super.getAssetEntry(className, kbArticle.getKbArticleId());
+		classPK = kbArticle.getKbArticleId();
+
+		if (kbArticle.getStatus() == WorkflowConstants.STATUS_APPROVED) {
+			classPK = kbArticle.getResourcePrimKey();
+		}
+
+		return super.getAssetEntry(className, classPK);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/KBArticleAssetRendererFactory.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/KBArticleAssetRendererFactory.java
@@ -66,13 +66,7 @@ public class KBArticleAssetRendererFactory
 		KBArticle kbArticle = getKBArticle(
 			classPK, WorkflowConstants.STATUS_ANY);
 
-		classPK = kbArticle.getKbArticleId();
-
-		if (kbArticle.getStatus() == WorkflowConstants.STATUS_APPROVED) {
-			classPK = kbArticle.getResourcePrimKey();
-		}
-
-		return super.getAssetEntry(className, classPK);
+		return super.getAssetEntry(className, kbArticle.getClassPK());
 	}
 
 	@Override


### PR DESCRIPTION
Hi @petershin 

Could you please help review this?

When kbarticle is approved, we use resourcePrimKey as assetentry's classPK.
When kbarticle is not approved, we use kbArticleId as assetentry's classPK.

The case always use kbArticleId as classPK. So the issue occurs.

cc @daviddotzhang

Regards,
Hai