### PR TITLE
LPS-90016 generate sample bnd.bnd and build.gradle

### DIFF
--- a/modules/util/portal-tools-rest-builder/samples/bnd.bnd
+++ b/modules/util/portal-tools-rest-builder/samples/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay ${configYAML.application.name-without-application} Implementation
+Bundle-SymbolicName: ${configYAML.apiPackagePath}.impl
+Bundle-Version: 1.0.0

--- a/modules/util/portal-tools-rest-builder/samples/build.gradle
+++ b/modules/util/portal-tools-rest-builder/samples/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.0.1"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:headless:${configYAML.application.name-without-application}:${configYAML.application.name-without-application}-api")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+}


### PR DESCRIPTION
Hi peter!

We've been discussing how to create new projects using the generator approach and it would be great if the generator created also the bnd.bnd and build.gradle of the api and implementation projects. 

I send this PR just to show how they should be. We should define a new property in the config file without the application suffix (and maybe use it for generating the application instead) and use it in both files.

What do you think?