### PR TITLE
LPS-90070 Handle extension dependencies

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/jaxrs/application/HeadlessCollaborationApplication.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/jaxrs/application/HeadlessCollaborationApplication.java
@@ -30,9 +30,13 @@ import org.osgi.service.component.annotations.Component;
 		"auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes=/*",
 		"auth.verifier.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
 		"auth.verifier.guest.allowed=true",
-		"oauth2.scopechecker.type=annotations",
+		"oauth2.scope.checker.type=annotations",
 		"osgi.jaxrs.application.base=/headless-collaboration",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.OAuth2)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyReader)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.PaginationContextProvider)",
 		"osgi.jaxrs.name=headless-collaboration-application.rest"
 	},
 	service = Application.class

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/jaxrs/application/HeadlessDocumentLibraryApplication.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/jaxrs/application/HeadlessDocumentLibraryApplication.java
@@ -30,9 +30,13 @@ import org.osgi.service.component.annotations.Component;
 		"auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes=/*",
 		"auth.verifier.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
 		"auth.verifier.guest.allowed=true",
-		"oauth2.scopechecker.type=annotations",
+		"oauth2.scope.checker.type=annotations",
 		"osgi.jaxrs.application.base=/headless-document-library",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.OAuth2)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyReader)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.PaginationContextProvider)",
 		"osgi.jaxrs.name=headless-document-library-application.rest"
 	},
 	service = Application.class

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/jaxrs/application/HeadlessFormApplication.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/jaxrs/application/HeadlessFormApplication.java
@@ -30,9 +30,13 @@ import org.osgi.service.component.annotations.Component;
 		"auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes=/*",
 		"auth.verifier.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
 		"auth.verifier.guest.allowed=true",
-		"oauth2.scopechecker.type=annotations",
+		"oauth2.scope.checker.type=annotations",
 		"osgi.jaxrs.application.base=/headless-form",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.OAuth2)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyReader)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.PaginationContextProvider)",
 		"osgi.jaxrs.name=headless-form-application.rest"
 	},
 	service = Application.class

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/jaxrs/application/HeadlessFoundationApplication.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/jaxrs/application/HeadlessFoundationApplication.java
@@ -30,9 +30,13 @@ import org.osgi.service.component.annotations.Component;
 		"auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes=/*",
 		"auth.verifier.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
 		"auth.verifier.guest.allowed=true",
-		"oauth2.scopechecker.type=annotations",
+		"oauth2.scope.checker.type=annotations",
 		"osgi.jaxrs.application.base=/headless-foundation",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.OAuth2)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyReader)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.PaginationContextProvider)",
 		"osgi.jaxrs.name=headless-foundation-application.rest"
 	},
 	service = Application.class

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/jaxrs/application/HeadlessWebExperienceApplication.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/jaxrs/application/HeadlessWebExperienceApplication.java
@@ -30,9 +30,13 @@ import org.osgi.service.component.annotations.Component;
 		"auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes=/*",
 		"auth.verifier.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
 		"auth.verifier.guest.allowed=true",
-		"oauth2.scopechecker.type=annotations",
+		"oauth2.scope.checker.type=annotations",
 		"osgi.jaxrs.application.base=/headless-web-experience",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.OAuth2)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyReader)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.PaginationContextProvider)",
 		"osgi.jaxrs.name=headless-web-experience-application.rest"
 	},
 	service = Application.class

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/jaxrs/application/HeadlessWorkflowApplication.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/src/main/java/com/liferay/headless/workflow/internal/jaxrs/application/HeadlessWorkflowApplication.java
@@ -30,9 +30,13 @@ import org.osgi.service.component.annotations.Component;
 		"auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes=/*",
 		"auth.verifier.auth.verifier.PortalSessionAuthVerifier.urls.includes=/*",
 		"auth.verifier.guest.allowed=true",
-		"oauth2.scopechecker.type=annotations",
+		"oauth2.scope.checker.type=annotations",
 		"osgi.jaxrs.application.base=/headless-workflow",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.OAuth2)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyReader)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.PaginationContextProvider)",
 		"osgi.jaxrs.name=headless-workflow-application.rest"
 	},
 	service = Application.class

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/AcceptLanguageContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/AcceptLanguageContextProvider.java
@@ -33,6 +33,7 @@ import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
  */
 @Component(
 	property = {
+		JaxrsWhiteboardConstants.JAX_RS_APPLICATION_SELECT + "=(osgi.jaxrs.extension.select=\\(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider\\))",
 		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
 		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.AcceptLanguageContextProvider",
 	},

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/AcceptLanguageContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/AcceptLanguageContextProvider.java
@@ -25,13 +25,18 @@ import org.apache.cxf.message.Message;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
 
 /**
  * @author Cristina González
  */
 @Component(
-	property = JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+	property = {
+		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.AcceptLanguageContextProvider",
+	},
+	scope = ServiceScope.PROTOTYPE,
 	service = ContextProvider.class
 )
 @Provider

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/PaginationContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/PaginationContextProvider.java
@@ -34,6 +34,7 @@ import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
  */
 @Component(
 	property = {
+		JaxrsWhiteboardConstants.JAX_RS_APPLICATION_SELECT + "=(osgi.jaxrs.extension.select=\\(osgi.jaxrs.name=vulcan.PaginationContextProvider\\))",
 		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
 		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.PaginationContextProvider",
 	},

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/PaginationContextProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/context/provider/PaginationContextProvider.java
@@ -26,13 +26,18 @@ import org.apache.cxf.jaxrs.ext.ContextProvider;
 import org.apache.cxf.message.Message;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
 
 /**
  * @author Zoltán Takács
  */
 @Component(
-	property = JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+	property = {
+		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.PaginationContextProvider",
+	},
+	scope = ServiceScope.PROTOTYPE,
 	service = ContextProvider.class
 )
 @Provider

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyReader.java
@@ -30,13 +30,18 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
 
 /**
  * @author Ivica Cardic
  */
 @Component(
-	property = JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+	property = {
+		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.JSONMessageBodyReader",
+	},
+	scope = ServiceScope.PROTOTYPE,
 	service = MessageBodyReader.class
 )
 @Consumes(MediaType.APPLICATION_JSON)

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyReader.java
@@ -38,6 +38,7 @@ import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
  */
 @Component(
 	property = {
+		JaxrsWhiteboardConstants.JAX_RS_APPLICATION_SELECT + "=(osgi.jaxrs.extension.select=\\(osgi.jaxrs.name=vulcan.JSONMessageBodyReader\\))",
 		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
 		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.JSONMessageBodyReader",
 	},

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyWriter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyWriter.java
@@ -40,6 +40,7 @@ import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
  */
 @Component(
 	property = {
+		JaxrsWhiteboardConstants.JAX_RS_APPLICATION_SELECT + "=(osgi.jaxrs.extension.select=\\(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter\\))",
 		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
 		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.JSONMessageBodyWriter",
 	},

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyWriter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/json/JSONMessageBodyWriter.java
@@ -32,13 +32,18 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
 
 /**
  * @author Ivica Cardic
  */
 @Component(
-	property = JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+	property = {
+		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+		JaxrsWhiteboardConstants.JAX_RS_NAME + "=vulcan.JSONMessageBodyWriter",
+	},
+	scope = ServiceScope.PROTOTYPE,
 	service = MessageBodyWriter.class
 )
 @Produces(MediaType.APPLICATION_JSON)

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/application.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/application.ftl
@@ -19,6 +19,10 @@ import org.osgi.service.component.annotations.Component;
 		"oauth2.scope.checker.type=annotations",
 		"osgi.jaxrs.application.base=${configYAML.application.baseURI}",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.OAuth2)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyReader)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.JSONMessageBodyWriter)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=vulcan.PaginationContextProvider)",
 		"osgi.jaxrs.name=${configYAML.application.name}.rest"
 	},
 	service = Application.class


### PR DESCRIPTION
Hey @petershin,

We've noticed that our jax-rs extensions from portal-vulcan where registered in all jax-rs application in the portal. 

With this PR our extensions will be registered only in the applications that depend on them, as a first approach, I have changed the application template to include all the extensions that we need.

This can be improved though, because some of these extensions are not always needed. In the ideal scenario, the generator will go through the openapi.yml of each bounded context and would add the needed extensions. e. g. `"osgi.jaxrs.extension.select(osgi.jaxrs.name=vulcan.AcceptLanguageContextProvider)"` should only be included in the applications that have a path that requires the AcceptContext, etc.

Do you think this is something we could do? Or should we wait until the generator is more mature?

Thanks a lot! :)

cc @nhpatt