### PR TITLE
LPS-90181 Add support for writeOnly/readOnly properties

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
@@ -235,6 +235,78 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
+  "/blog-posting/{blog-posting-id}/categories":
+    get:
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+        - in: path
+          name: blog-posting-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                items:
+                  format: int64
+                  type: integer
+                type: array
+          description: ""
+    post:
+      parameters:
+        - in: path
+          name: blog-posting-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              format: int64
+              type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                format: int64
+                type: integer
+          description: ""
+  "/blog-posting/{blog-posting-id}/categories/batch-create":
+    post:
+      parameters:
+        - in: path
+          name: blog-posting-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              format: int64
+              type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                format: int64
+                type: integer
+          description: ""
   "/blog-posting/{blog-posting-id}/comment":
     get:
       parameters:

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
@@ -64,13 +64,25 @@ components:
           format: int64
           type: integer
         image:
-          $ref: "#/components/schemas/ImageObject"
+          allOf:
+            - $ref: "#/components/schemas/ImageObject"
+          readOnly: true
+        imageId:
+          format: int64
+          type: integer
+          writeOnly: true
         keywords:
           items:
             type: string
           type: array
         repository:
-          $ref: "#/components/schemas/ImageObjectRepository"
+          allOf:
+            - $ref: "#/components/schemas/ImageObjectRepository"
+          readOnly: true
+        repositoryId:
+          format: int64
+          type: integer
+          writeOnly: true
         self:
           format: uri
           type: string
@@ -157,7 +169,14 @@ components:
         images:
           items:
             $ref: "#/components/schemas/ImageObject"
+          readOnly: true
           type: array
+        imagesIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
         name:
           type: string
         self:

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
@@ -35,11 +35,10 @@ components:
         comment:
           $ref: "#/components/schemas/Comment"
         contentSpace:
-          format: uri
-          type: string
+          format: int64
+          type: integer
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -78,8 +77,7 @@ components:
         comments:
           $ref: "#/components/schemas/Comment"
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         id:
           format: int64
           type: integer
@@ -87,6 +85,35 @@ components:
           format: uri
           type: string
         text:
+          type: string
+      type: object
+    Creator:
+      description: https://www.schema.org/Creator
+      properties:
+        additionalName:
+          type: string
+        alternateName:
+          type: string
+        email:
+          type: string
+        familyName:
+          type: string
+        givenName:
+          type: string
+        id:
+          format: int64
+          type: integer
+        image:
+          format: uri
+          type: string
+        jobTitle:
+          type: string
+        name:
+          type: string
+        profileURL:
+          type: string
+        self:
+          format: uri
           type: string
       type: object
     ImageObject:
@@ -122,7 +149,9 @@ components:
           format: int64
           type: integer
         images:
-          $ref: "#/components/schemas/ImageObject"
+          items:
+            $ref: "#/components/schemas/ImageObject"
+          type: array
         name:
           type: string
         self:
@@ -334,6 +363,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
+          description: ""
+  "/creator/{creator-id}":
+    get:
+      parameters:
+      - in: path
+        name: creator-id
+        required: true
+        schema:
+          format: int64
+          type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Creator"
           description: ""
   "/image-object-repository/{image-object-repository-id}":
     get:

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
@@ -30,10 +30,14 @@ components:
         caption:
           type: string
         category:
-          format: uri
-          type: string
+          items:
+            format: int64
+            type: integer
+          type: array
         comment:
-          $ref: "#/components/schemas/Comment"
+          items:
+            $ref: "#/components/schemas/Comment"
+          type: array
         contentSpace:
           format: int64
           type: integer
@@ -75,7 +79,9 @@ components:
       description: https://www.schema.org/Comment
       properties:
         comments:
-          $ref: "#/components/schemas/Comment"
+          items:
+            $ref: "#/components/schemas/Comment"
+          type: array
         creator:
           $ref: "#/components/schemas/Creator"
         id:
@@ -367,12 +373,12 @@ paths:
   "/creator/{creator-id}":
     get:
       parameters:
-      - in: path
-        name: creator-id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: creator-id
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         200:
           content:

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -94,7 +94,13 @@ components:
         fileExtension:
           type: string
         folder:
-          $ref: "#/components/schemas/Folder"
+          allOf:
+            - $ref: "#/components/schemas/Folder"
+          readOnly: true
+        folderId:
+          format: int64
+          type: integer
+          writeOnly: true
         id:
           format: int64
           type: integer
@@ -124,9 +130,22 @@ components:
         documents:
           items:
             $ref: "#/components/schemas/Document"
+          readOnly: true
           type: array
+        documentsIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
         documentsRepository:
-          $ref: "#/components/schemas/Folder"
+          allOf:
+            - $ref: "#/components/schemas/Folder"
+          readOnly: true
+        documentsRepositoryId:
+          format: int64
+          type: integer
+          writeOnly: true
         id:
           format: int64
           type: integer

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -6,8 +6,7 @@ components:
         comments:
           $ref: "#/components/schemas/Comment"
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         id:
           format: int64
           type: integer
@@ -15,6 +14,35 @@ components:
           format: uri
           type: string
         text:
+          type: string
+      type: object
+    Creator:
+      description: https://www.schema.org/Creator
+      properties:
+        additionalName:
+          type: string
+        alternateName:
+          type: string
+        email:
+          type: string
+        familyName:
+          type: string
+        givenName:
+          type: string
+        id:
+          format: int64
+          type: integer
+        image:
+          format: uri
+          type: string
+        jobTitle:
+          type: string
+        name:
+          type: string
+        profileURL:
+          type: string
+        self:
+          format: uri
           type: string
       type: object
     Document:
@@ -48,8 +76,7 @@ components:
           format: uri
           type: string
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -92,8 +119,6 @@ components:
           type: string
         documents:
           $ref: "#/components/schemas/Document"
-        folders:
-          $ref: "#/components/schemas/Folder"
         id:
           format: int64
           type: integer
@@ -111,6 +136,22 @@ info:
   version: 1.0.0
 openapi: 3.0.1
 paths:
+  "/creator/{creator-id}":
+    get:
+      parameters:
+      - in: path
+        name: creator-id
+        required: true
+        schema:
+          format: int64
+          type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Creator"
+          description: ""
   "/document/{document-id}":
     delete:
       parameters:

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -4,7 +4,9 @@ components:
       description: https://www.schema.org/Comment
       properties:
         comments:
-          $ref: "#/components/schemas/Comment"
+          items:
+            $ref: "#/components/schemas/Comment"
+          type: array
         creator:
           $ref: "#/components/schemas/Creator"
         id:
@@ -70,8 +72,10 @@ components:
               type: number
           type: object
         category:
-          format: uri
-          type: string
+          items:
+            format: int64
+            type: integer
+          type: array
         contentUrl:
           format: uri
           type: string
@@ -118,7 +122,11 @@ components:
         description:
           type: string
         documents:
-          $ref: "#/components/schemas/Document"
+          items:
+            $ref: "#/components/schemas/Document"
+          type: array
+        documentsRepository:
+          $ref: "#/components/schemas/Folder"
         id:
           format: int64
           type: integer
@@ -128,7 +136,9 @@ components:
           format: uri
           type: string
         subFolders:
-          $ref: "#/components/schemas/Folder"
+          items:
+            $ref: "#/components/schemas/Folder"
+          type: array
       type: object
 info:
   description: ""
@@ -139,12 +149,12 @@ paths:
   "/creator/{creator-id}":
     get:
       parameters:
-      - in: path
-        name: creator-id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: creator-id
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         200:
           content:

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -191,6 +191,78 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
+  "/document/{document-id}/categories":
+    get:
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+        - in: path
+          name: document-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                items:
+                  format: int64
+                  type: integer
+                type: array
+          description: ""
+    post:
+      parameters:
+        - in: path
+          name: document-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              format: int64
+              type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                format: int64
+                type: integer
+          description: ""
+  "/document/{document-id}/categories/batch-create":
+    post:
+      parameters:
+        - in: path
+          name: document-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              format: int64
+              type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                format: int64
+                type: integer
+          description: ""
   "/document/{document-id}/comment":
     get:
       parameters:

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -1,5 +1,34 @@
 components:
   schemas:
+    Creator:
+      description: https://www.schema.org/Creator
+      properties:
+        additionalName:
+          type: string
+        alternateName:
+          type: string
+        email:
+          type: string
+        familyName:
+          type: string
+        givenName:
+          type: string
+        id:
+          format: int64
+          type: integer
+        image:
+          format: uri
+          type: string
+        jobTitle:
+          type: string
+        name:
+          type: string
+        profileURL:
+          type: string
+        self:
+          format: uri
+          type: string
+      type: object
     Form:
       description: https://www.schema.org/Form
       properties:
@@ -8,11 +37,10 @@ components:
             type: string
           type: array
         contentSpace:
-          format: uri
-          type: string
+          format: int64
+          type: integer
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -43,6 +71,7 @@ components:
       description: https://www.schema.org/FormDocument
       properties:
         contentUrl:
+          format: uri
           type: string
         encodingFormat:
           type: string
@@ -63,8 +92,7 @@ components:
       description: https://www.schema.org/FormRecord
       properties:
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -109,11 +137,10 @@ components:
             type: string
           type: array
         contentSpace:
-          format: uri
-          type: string
+          format: int64
+          type: integer
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -336,6 +363,22 @@ paths:
                 items:
                   $ref: "#/components/schemas/FormStructure"
                 type: array
+          description: ""
+  "/creator/{creator-id}":
+    get:
+      parameters:
+        - in: path
+          name: creator-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Creator"
           description: ""
   "/form-document/{form-document-id}":
     delete:

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -57,7 +57,14 @@ components:
         formRecords:
           items:
             $ref: "#/components/schemas/FormRecord"
+          readOnly: true
           type: array
+        formRecordsIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
         id:
           format: int64
           type: integer
@@ -67,7 +74,13 @@ components:
           format: uri
           type: string
         structure:
-          $ref: "#/components/schemas/FormStructure"
+          allOf:
+            - $ref: "#/components/schemas/FormStructure"
+          readOnly: true
+        structureId:
+          format: int64
+          type: integer
+          writeOnly: true
       type: object
     FormDocument:
       description: https://www.schema.org/FormDocument
@@ -110,7 +123,13 @@ components:
           description: https://www.schema.org/FormFieldValue
           properties:
             document:
-              $ref: "#/components/schemas/FormDocument"
+              allOf:
+                - $ref: "#/components/schemas/FormDocument"
+              readOnly: true
+            documentId:
+              format: int64
+              type: integer
+              writeOnly: true
             id:
               format: int64
               type: integer
@@ -123,7 +142,13 @@ components:
               type: string
           type: object
         form:
-          $ref: "#/components/schemas/Form"
+          allOf:
+            - $ref: "#/components/schemas/Form"
+          readOnly: true
+        formId:
+          format: int64
+          type: integer
+          writeOnly: true
         id:
           format: int64
           type: integer

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -55,7 +55,9 @@ components:
         description:
           type: string
         formRecords:
-          $ref: "#/components/schemas/FormRecord"
+          items:
+            $ref: "#/components/schemas/FormRecord"
+          type: array
         id:
           format: int64
           type: integer

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
@@ -8,9 +8,21 @@ components:
             type: string
           type: array
         category:
-          $ref: "#/components/schemas/Category"
+          allOf:
+            - $ref: "#/components/schemas/Category"
+          readOnly: true
+        categoryId:
+          format: int64
+          type: integer
+          writeOnly: true
         creator:
-          $ref: "#/components/schemas/UserAccount"
+          allOf:
+            - $ref: "#/components/schemas/UserAccount"
+          readOnly: true
+        creatorId:
+          format: int64
+          type: integer
+          writeOnly: true
         dateCreated:
           format: date-time
           type: string
@@ -32,7 +44,13 @@ components:
             $ref: "#/components/schemas/Category"
           type: array
         vocabulary:
-          $ref: "#/components/schemas/Vocabulary"
+          allOf:
+            - $ref: "#/components/schemas/Vocabulary"
+          readOnly: true
+        vocabularyId:
+          format: int64
+          type: integer
+          writeOnly: true
       type: object
     Email:
       description: https://www.schema.org/Email
@@ -84,11 +102,25 @@ components:
             address:
               items:
                 $ref: "#/components/schemas/PostalAddress"
+              readOnly: true
               type: array
+            addressIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
             email:
               items:
                 $ref: "#/components/schemas/Email"
+              readOnly: true
               type: array
+            emailIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
             id:
               format: int64
               type: integer
@@ -98,11 +130,25 @@ components:
             telephone:
               items:
                 $ref: "#/components/schemas/Phone"
+              readOnly: true
               type: array
+            telephoneIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
             webUrl:
               items:
                 $ref: "#/components/schemas/WebUrl"
+              readOnly: true
               type: array
+            webUrlIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
           type: object
         id:
           format: int64
@@ -127,11 +173,24 @@ components:
         members:
           items:
             $ref: "#/components/schemas/UserAccount"
+          readOnly: true
           type: array
+        membersIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
         name:
           type: string
         parentOrganization:
-          $ref: "#/components/schemas/Organization"
+          allOf:
+            - $ref: "#/components/schemas/Organization"
+          readOnly: true
+        parentOrganizationId:
+          format: int64
+          type: integer
+          writeOnly: true
         self:
           format: uri
           type: string
@@ -166,7 +225,14 @@ components:
         subOrganization:
           items:
             $ref: "#/components/schemas/Organization"
+          readOnly: true
           type: array
+        subOrganizationIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
       type: object
     Phone:
       description: https://www.schema.org/Phone
@@ -254,11 +320,25 @@ components:
             address:
               items:
                 $ref: "#/components/schemas/PostalAddress"
+              readOnly: true
               type: array
+            addressIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
             email:
               items:
                 $ref: "#/components/schemas/Email"
+              readOnly: true
               type: array
+            emailIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
             facebook:
               type: string
             id:
@@ -276,13 +356,27 @@ components:
             telephone:
               items:
                 $ref: "#/components/schemas/Phone"
+              readOnly: true
               type: array
+            telephoneIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
             twitter:
               type: string
             webUrl:
               items:
                 $ref: "#/components/schemas/WebUrl"
+              readOnly: true
               type: array
+            webUrlIds:
+              items:
+                format: int64
+                type: integer
+              type: array
+              writeOnly: true
           type: object
         dashboardURL:
           type: string
@@ -307,7 +401,14 @@ components:
         myOrganizations:
           items:
             $ref: "#/components/schemas/Organization"
+          readOnly: true
           type: array
+        myOrganizationsIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
         name:
           type: string
         profileURL:
@@ -315,7 +416,14 @@ components:
         roles:
           items:
             $ref: "#/components/schemas/Role"
+          readOnly: true
           type: array
+        rolesIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
         self:
           format: uri
           type: string
@@ -361,7 +469,14 @@ components:
         vocabularyCategories:
           items:
             $ref: "#/components/schemas/Category"
+          readOnly: true
           type: array
+        vocabularyCategoriesIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
       type: object
     WebUrl:
       description: https://www.schema.org/WebUrl

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
@@ -32,50 +32,6 @@ components:
         vocabulary:
           $ref: "#/components/schemas/Vocabulary"
       type: object
-    ContentSpace:
-      description: https://www.schema.org/ContentSpace
-      properties:
-        availableLanguages:
-          items:
-            type: string
-          type: array
-        blogPosts:
-          format: uri
-          type: string
-        contentStructures:
-          format: uri
-          type: string
-        creator:
-          $ref: "#/components/schemas/UserAccount"
-        description:
-          type: string
-        documentsRepository:
-          format: uri
-          type: string
-        formStructures:
-          format: uri
-          type: string
-        forms:
-          format: uri
-          type: string
-        id:
-          format: int64
-          type: integer
-        keywords:
-          $ref: "#/components/schemas/Keyword"
-        name:
-          type: string
-        self:
-          format: uri
-          type: string
-        structuredContents:
-          format: uri
-          type: string
-        vocabularies:
-          $ref: "#/components/schemas/Vocabulary"
-        webSite:
-          $ref: "#/components/schemas/WebSite"
-      type: object
     Email:
       description: https://www.schema.org/Email
       properties:
@@ -94,7 +50,8 @@ components:
       description: https://www.schema.org/Keyword
       properties:
         contentSpace:
-          $ref: "#/components/schemas/ContentSpace"
+          format: int64
+          type: integer
         creator:
           $ref: "#/components/schemas/UserAccount"
         dateCreated:
@@ -196,8 +153,6 @@ components:
           type: object
         subOrganization:
           $ref: "#/components/schemas/Organization"
-        website:
-          $ref: "#/components/schemas/WebSite"
       type: object
     Phone:
       description: https://www.schema.org/Phone
@@ -329,8 +284,6 @@ components:
           type: string
         myOrganizations:
           $ref: "#/components/schemas/Organization"
-        myWebSites:
-          $ref: "#/components/schemas/WebSite"
         name:
           type: string
         profileURL:
@@ -355,7 +308,8 @@ components:
             type: string
           type: array
         contentSpace:
-          $ref: "#/components/schemas/ContentSpace"
+          format: int64
+          type: integer
         creator:
           $ref: "#/components/schemas/UserAccount"
         dateCreated:
@@ -376,40 +330,6 @@ components:
           type: string
         vocabularyCategories:
           $ref: "#/components/schemas/Category"
-      type: object
-    WebSite:
-      description: https://www.schema.org/WebSite
-      properties:
-        availableLanguages:
-          items:
-            type: string
-          type: array
-        contentSpace:
-          $ref: "#/components/schemas/ContentSpace"
-        creator:
-          $ref: "#/components/schemas/UserAccount"
-        description:
-          type: string
-        id:
-          format: int64
-          type: integer
-        members:
-          $ref: "#/components/schemas/UserAccount"
-        membershipType:
-          type: string
-        name:
-          type: string
-        privateUrl:
-          type: string
-        publicUrl:
-          type: string
-        self:
-          format: uri
-          type: string
-        webSite:
-          $ref: "#/components/schemas/WebSite"
-        webSites:
-          $ref: "#/components/schemas/WebSite"
       type: object
     WebUrl:
       description: https://www.schema.org/WebUrl
@@ -587,22 +507,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Category"
-          description: ""
-  "/content-space/{content-space-id}":
-    get:
-      parameters:
-        - in: path
-          name: content-space-id
-          required: true
-          schema:
-            format: int64
-            type: integer
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ContentSpace"
           description: ""
   "/content-space/{content-space-id}/keywords":
     get:
@@ -914,32 +818,6 @@ paths:
               schema:
                 items:
                   $ref: "#/components/schemas/Role"
-                type: array
-          description: ""
-  "/my-user-account/{my-user-account-id}/web-site":
-    get:
-      parameters:
-        - in: query
-          name: page
-          schema:
-            type: integer
-        - in: query
-          name: per_page
-          schema:
-            type: integer
-        - in: path
-          name: my-user-account-id
-          required: true
-          schema:
-            format: int64
-            type: integer
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/WebSite"
                 type: array
           description: ""
   "/organization":
@@ -1261,32 +1139,6 @@ paths:
                   $ref: "#/components/schemas/Role"
                 type: array
           description: ""
-  "/user-account/{user-account-id}/web-site":
-    get:
-      parameters:
-        - in: query
-          name: page
-          schema:
-            type: integer
-        - in: query
-          name: per_page
-          schema:
-            type: integer
-        - in: path
-          name: user-account-id
-          required: true
-          schema:
-            format: int64
-            type: integer
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/WebSite"
-                type: array
-          description: ""
   "/vocabularies/{vocabularies-id}":
     delete:
       parameters:
@@ -1403,22 +1255,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
-  "/web-site/{web-site-id}":
-    get:
-      parameters:
-        - in: path
-          name: web-site-id
-          required: true
-          schema:
-            format: int64
-            type: integer
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WebSite"
-          description: ""
   "/web-site/{web-site-id}/user-account":
     get:
       parameters:
@@ -1443,32 +1279,6 @@ paths:
               schema:
                 items:
                   $ref: "#/components/schemas/UserAccount"
-                type: array
-          description: ""
-  "/web-site/{web-site-id}/web-site":
-    get:
-      parameters:
-        - in: query
-          name: page
-          schema:
-            type: integer
-        - in: query
-          name: per_page
-          schema:
-            type: integer
-        - in: path
-          name: web-site-id
-          required: true
-          schema:
-            format: int64
-            type: integer
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: "#/components/schemas/WebSite"
                 type: array
           description: ""
   "/web-urls":

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
@@ -28,7 +28,9 @@ components:
           format: uri
           type: string
         subcategories:
-          $ref: "#/components/schemas/Category"
+          items:
+            $ref: "#/components/schemas/Category"
+          type: array
         vocabulary:
           $ref: "#/components/schemas/Vocabulary"
       type: object
@@ -80,9 +82,13 @@ components:
           description: https://www.schema.org/ContactInformation
           properties:
             address:
-              $ref: "#/components/schemas/PostalAddress"
+              items:
+                $ref: "#/components/schemas/PostalAddress"
+              type: array
             email:
-              $ref: "#/components/schemas/Email"
+              items:
+                $ref: "#/components/schemas/Email"
+              type: array
             id:
               format: int64
               type: integer
@@ -90,9 +96,13 @@ components:
               format: uri
               type: string
             telephone:
-              $ref: "#/components/schemas/Phone"
+              items:
+                $ref: "#/components/schemas/Phone"
+              type: array
             webUrl:
-              $ref: "#/components/schemas/WebUrl"
+              items:
+                $ref: "#/components/schemas/WebUrl"
+              type: array
           type: object
         id:
           format: int64
@@ -115,7 +125,9 @@ components:
           format: uri
           type: string
         members:
-          $ref: "#/components/schemas/UserAccount"
+          items:
+            $ref: "#/components/schemas/UserAccount"
+          type: array
         name:
           type: string
         parentOrganization:
@@ -152,7 +164,9 @@ components:
               type: string
           type: object
         subOrganization:
-          $ref: "#/components/schemas/Organization"
+          items:
+            $ref: "#/components/schemas/Organization"
+          type: array
       type: object
     Phone:
       description: https://www.schema.org/Phone
@@ -238,9 +252,13 @@ components:
           description: https://www.schema.org/ContactInformation
           properties:
             address:
-              $ref: "#/components/schemas/PostalAddress"
+              items:
+                $ref: "#/components/schemas/PostalAddress"
+              type: array
             email:
-              $ref: "#/components/schemas/Email"
+              items:
+                $ref: "#/components/schemas/Email"
+              type: array
             facebook:
               type: string
             id:
@@ -256,11 +274,15 @@ components:
             sms:
               type: string
             telephone:
-              $ref: "#/components/schemas/Phone"
+              items:
+                $ref: "#/components/schemas/Phone"
+              type: array
             twitter:
               type: string
             webUrl:
-              $ref: "#/components/schemas/WebUrl"
+              items:
+                $ref: "#/components/schemas/WebUrl"
+              type: array
           type: object
         dashboardURL:
           type: string
@@ -283,22 +305,30 @@ components:
         jobTitle:
           type: string
         myOrganizations:
-          $ref: "#/components/schemas/Organization"
+          items:
+            $ref: "#/components/schemas/Organization"
+          type: array
         name:
           type: string
         profileURL:
           type: string
         roles:
-          $ref: "#/components/schemas/Role"
+          items:
+            $ref: "#/components/schemas/Role"
+          type: array
         self:
           format: uri
           type: string
         tasksAssignedToMe:
-          format: uri
-          type: string
+          items:
+            format: uri
+            type: string
+          type: array
         tasksAssignedToMyRoles:
-          format: uri
-          type: string
+          items:
+            format: uri
+            type: string
+          type: array
       type: object
     Vocabulary:
       description: https://www.schema.org/Vocabulary
@@ -329,7 +359,9 @@ components:
           format: uri
           type: string
         vocabularyCategories:
-          $ref: "#/components/schemas/Category"
+          items:
+            $ref: "#/components/schemas/Category"
+          type: array
       type: object
     WebUrl:
       description: https://www.schema.org/WebUrl

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -146,7 +146,13 @@ components:
           format: int64
           type: integer
         contentStructure:
-          $ref: "#/components/schemas/ContentStructure"
+          allOf:
+            - $ref: "#/components/schemas/ContentStructure"
+          readOnly: true
+        contentStructureId:
+          format: int64
+          type: integer
+          writeOnly: true
         creator:
           $ref: "#/components/schemas/Creator"
         dateCreated:
@@ -194,7 +200,12 @@ components:
             dataType:
               type: string
             document:
-              $ref: "#/components/schemas/ContentDocument"
+              allOf:
+                - $ref: "#/components/schemas/ContentDocument"
+            documentId:
+              format: int64
+              type: integer
+              writeOnly: true
             filterAndSortIdentifier:
               type: string
             geo:
@@ -227,7 +238,13 @@ components:
               format: uri
               type: string
             structuredContent:
-              $ref: "#/components/schemas/StructuredContent"
+              allOf:
+                - $ref: "#/components/schemas/StructuredContent"
+              readOnly: true
+            structuredContentId:
+              format: int64
+              type: integer
+              writeOnly: true
             value:
               type: string
           type: object

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -527,6 +527,78 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
+  "/structured-contents/{structured-contents-id}/categories":
+    get:
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+        - in: path
+          name: structured-contents-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                items:
+                  format: int64
+                  type: integer
+                type: array
+          description: ""
+    post:
+      parameters:
+        - in: path
+          name: structured-contents-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              format: int64
+              type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                format: int64
+                type: integer
+          description: ""
+  "/structured-contents/{structured-contents-id}/categories/batch-create":
+    post:
+      parameters:
+        - in: path
+          name: structured-contents-id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              format: int64
+              type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                format: int64
+                type: integer
+          description: ""
   "/structured-contents/{structured-contents-id}/comment":
     get:
       parameters:

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -24,8 +24,7 @@ components:
         comments:
           $ref: "#/components/schemas/Comment"
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         id:
           format: int64
           type: integer
@@ -39,10 +38,10 @@ components:
       description: https://www.schema.org/ContentDocument
       properties:
         contentUrl:
-          type: string
-        creator:
           format: uri
           type: string
+        creator:
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -72,11 +71,10 @@ components:
             type: string
           type: array
         contentSpace:
-          format: uri
-          type: string
+          format: int64
+          type: integer
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -89,6 +87,36 @@ components:
           format: int64
           type: integer
         name:
+          type: string
+        self:
+          format: uri
+          type: string
+      type: object
+    Creator:
+      description: https://www.schema.org/Creator
+      properties:
+        additionalName:
+          type: string
+        alternateName:
+          type: string
+        email:
+          type: string
+        familyName:
+          type: string
+        givenName:
+          type: string
+        id:
+          format: int64
+          type: integer
+        image:
+          format: uri
+          type: string
+        jobTitle:
+          type: string
+        name:
+          type: string
+        profileURL:
+          format: uri
           type: string
         self:
           format: uri
@@ -109,13 +137,12 @@ components:
         comment:
           $ref: "#/components/schemas/Comment"
         contentSpace:
-          format: uri
-          type: string
+          format: int64
+          type: integer
         contentStructure:
           $ref: "#/components/schemas/ContentStructure"
         creator:
-          format: uri
-          type: string
+          $ref: "#/components/schemas/Creator"
         dateCreated:
           format: date-time
           type: string
@@ -420,6 +447,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ContentStructure"
+          description: ""
+  "/creator/{creator-id}":
+    get:
+      parameters:
+      - in: path
+        name: creator-id
+        required: true
+        schema:
+          format: int64
+          type: integer
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Creator"
           description: ""
   "/structured-contents/{structured-contents-id}":
     delete:

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -22,7 +22,9 @@ components:
       description: https://www.schema.org/Comment
       properties:
         comments:
-          $ref: "#/components/schemas/Comment"
+          items:
+            $ref: "#/components/schemas/Comment"
+          type: array
         creator:
           $ref: "#/components/schemas/Creator"
         id:
@@ -132,10 +134,14 @@ components:
             type: string
           type: array
         category:
-          format: uri
-          type: string
+          items:
+            format: int64
+            type: integer
+          type: array
         comment:
-          $ref: "#/components/schemas/Comment"
+          items:
+            $ref: "#/components/schemas/Comment"
+          type: array
         contentSpace:
           format: int64
           type: integer
@@ -451,12 +457,12 @@ paths:
   "/creator/{creator-id}":
     get:
       parameters:
-      - in: path
-        name: creator-id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: creator-id
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         200:
           content:

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
@@ -54,7 +54,9 @@ components:
           format: int64
           type: integer
         logs:
-          $ref: "#/components/schemas/WorkflowLog"
+          items:
+            $ref: "#/components/schemas/WorkflowLog"
+          type: array
         name:
           type: string
         object:

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
@@ -28,7 +28,13 @@ components:
         state:
           type: string
         task:
-          $ref: "#/components/schemas/WorkflowTask"
+          allOf:
+            - $ref: "#/components/schemas/WorkflowTask"
+          readOnly: true
+        taskId:
+          format: int64
+          type: integer
+          writeOnly: true
         type:
           type: string
       type: object
@@ -56,7 +62,14 @@ components:
         logs:
           items:
             $ref: "#/components/schemas/WorkflowLog"
+          readOnly: true
           type: array
+        logsIds:
+          items:
+            format: int64
+            type: integer
+          type: array
+          writeOnly: true
         name:
           type: string
         object:


### PR DESCRIPTION
Hi Peter! :)

We want to support this syntax (right now the generator is failing with it):
```
image:
  allOf:
    - $ref: "#/components/schemas/ImageObject"
  readOnly: true
imageId:
  format: int64
  type: integer
  writeOnly: true
```
Basically what it should generate is a DTO with a `ImageObject` called `image` and a long field `imageId`. We could add validation later. 

The idea is sending a json object (POST/PUT) with imageId filled but rendering image when doing a GET request.

I could send the PR or explain it in Skype if you want :)
