### PR TITLE
LPS-90012 Create new baseDir property in YAML

### DIFF
--- a/modules/util/portal-tools-rest-builder/samples/rest-config.yaml
+++ b/modules/util/portal-tools-rest-builder/samples/rest-config.yaml
@@ -9,3 +9,4 @@ application:
         guestAllowed: true
         oAuth2: true
 author: "John Doe"
+baseDir: "../sample-impl/src/main/java"

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -103,7 +103,12 @@ public class RESTBuilder {
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(_configYAML.getImplDir());
+		if(_configYAML.getBaseDir() != null) {
+			sb.append(_configYAML.getBaseDir());
+		} else {
+			sb.append(_configYAML.getImplDir());
+		}
+
 		sb.append("/");
 
 		String apiPackagePath = _configYAML.getApiPackagePath();
@@ -130,7 +135,12 @@ public class RESTBuilder {
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(_configYAML.getImplDir());
+		if(_configYAML.getBaseDir() != null) {
+			sb.append(_configYAML.getBaseDir());
+		} else {
+			sb.append(_configYAML.getImplDir());
+		}
+
 		sb.append("/");
 
 		String apiPackagePath = _configYAML.getApiPackagePath();
@@ -174,7 +184,12 @@ public class RESTBuilder {
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(_configYAML.getImplDir());
+		if(_configYAML.getBaseDir() != null) {
+			sb.append(_configYAML.getBaseDir());
+		} else {
+			sb.append(_configYAML.getImplDir());
+		}
+
 		sb.append("/../resources/OSGI-INF/");
 		sb.append(CamelCaseUtil.fromCamelCase(schemaName));
 		sb.append(".properties");
@@ -213,7 +228,12 @@ public class RESTBuilder {
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(_configYAML.getImplDir());
+		if(_configYAML.getBaseDir() != null) {
+			sb.append(_configYAML.getBaseDir());
+		} else {
+			sb.append(_configYAML.getImplDir());
+		}
+
 		sb.append("/");
 
 		String apiPackagePath = _configYAML.getApiPackagePath();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
@@ -35,6 +35,10 @@ public class ConfigYAML {
 		return _author;
 	}
 
+	public String getBaseDir() {
+		return _baseDir;
+	}
+
 	public String getImplDir() {
 		return _implDir;
 	}
@@ -55,6 +59,10 @@ public class ConfigYAML {
 		_author = author;
 	}
 
+	public void setBaseDir(String baseDir) {
+		_baseDir = baseDir;
+	}
+
 	public void setImplDir(String implDir) {
 		_implDir = implDir;
 	}
@@ -63,6 +71,7 @@ public class ConfigYAML {
 	private String _apiPackagePath;
 	private Application _application;
 	private String _author;
+	private String _baseDir;
 	private String _implDir = "src/main/java";
 
 }


### PR DESCRIPTION
Hey @petershin,
I added a new property in config yaml file called `baseDir` that indicates the directory that the generator is going to create the *Application and *ResourceImpl files. If this property doesn't exists in the config file, the generator will use the default `implDir`. I don't know if the name `baseDir` is correct. Maybe it's better `implDir`. What do you think? Do we let the user customize that?

Thanks :)