### PR TITLE
LPS-90230 Support for any of

### DIFF
--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/build.gradle
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.9.8"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.9.8"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.8"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.0.1"
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Data.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Data.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.web.experience.dto.v1_0;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@XmlRootElement(name = "Data")
+public class Data extends Values {
+
+	public String getData() {
+		return _data;
+	}
+
+	public void setData(String data) {
+		_data = data;
+	}
+
+	private String _data;
+
+}

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Document.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.web.experience.dto.v1_0;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@XmlRootElement(name = "Document")
+public class Document extends Values {
+
+	public ContentDocument getDocument() {
+		return _document;
+	}
+
+	public Long getDocumentId() {
+		return _documentId;
+	}
+
+	public void setDocument(ContentDocument document) {
+		_document = document;
+	}
+
+	public void setDocumentId(Long documentId) {
+		_documentId = documentId;
+	}
+
+	private ContentDocument _document;
+	private Long _documentId;
+
+}

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Geo.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Geo.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.web.experience.dto.v1_0;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@XmlRootElement(name = "Geo")
+public class Geo extends Values {
+
+	public Number getLatitude() {
+		return _latitude;
+	}
+
+	public Number getLongitude() {
+		return _longitude;
+	}
+
+	public void setLatitude(Number latitude) {
+		_latitude = latitude;
+	}
+
+	public void setLongitude(Number longitude) {
+		_longitude = longitude;
+	}
+
+	private Number _latitude;
+	private Number _longitude;
+
+}

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Link.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Link.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.web.experience.dto.v1_0;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@XmlRootElement(name = "Link")
+public class Link extends Values {
+
+	public String getLink() {
+		return _link;
+	}
+
+	public void setLink(String link) {
+		_link = link;
+	}
+
+	private String _link;
+
+}

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/StructuredContent.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/StructuredContent.java
@@ -100,7 +100,7 @@ public class StructuredContent {
 		return _title;
 	}
 
-	public Values getValues() {
+	public Values[] getValues() {
 		return _values;
 	}
 
@@ -178,7 +178,7 @@ public class StructuredContent {
 		_title = title;
 	}
 
-	public void setValues(Values values) {
+	public void setValues(Values[] values) {
 		_values = values;
 	}
 
@@ -200,6 +200,6 @@ public class StructuredContent {
 	private RenderedContentsByTemplate _renderedContentsByTemplate;
 	private String _self;
 	private String _title;
-	private Values _values;
+	private Values[] _values;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/StructuredContentValue.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/StructuredContentValue.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.web.experience.dto.v1_0;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@XmlRootElement(name = "StructuredContentValue")
+public class StructuredContentValue extends Values {
+
+	public StructuredContent getStructuredContentValue() {
+		return _structuredContentValue;
+	}
+
+	public Long getStructuredContentValueId() {
+		return _structuredContentValueId;
+	}
+
+	public void setStructuredContentValue(
+		StructuredContent structuredContentValue) {
+
+		_structuredContentValue = structuredContentValue;
+	}
+
+	public void setStructuredContentValueId(Long structuredContentValueId) {
+		_structuredContentValueId = structuredContentValueId;
+	}
+
+	private StructuredContent _structuredContentValue;
+	private Long _structuredContentValueId;
+
+}

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Values.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/dto/v1_0/Values.java
@@ -14,6 +14,9 @@
 
 package com.liferay.headless.web.experience.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import javax.annotation.Generated;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -23,6 +26,15 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @generated
  */
 @Generated("")
+@JsonSubTypes( {
+		@JsonSubTypes.Type(value = Data.class, name = "Data"),
+		@JsonSubTypes.Type(value = Document.class, name = "Document"),
+		@JsonSubTypes.Type(value = Geo.class, name = "Geo"),
+		@JsonSubTypes.Type(value = Link.class, name = "Link"),
+		@JsonSubTypes.Type(value = StructuredContentValue.class, name = "StructuredContentValue")
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+	include = JsonTypeInfo.As.PROPERTY, property = "discriminator")
 @XmlRootElement(name = "Values")
 public class Values {
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -230,27 +230,21 @@ components:
                     geo:
                       description: https://www.schema.org/GeoCoordinates
                       properties:
-                        id:
-                          format: int64
-                          type: integer
                         latitude:
                           type: number
                         longitude:
                           type: number
-                        self:
-                          format: uri
-                          type: string
                       type: object
                 - properties:
                     link:
                       format: uri
                       type: string
                 - properties:
-                    structuredContent:
+                    structuredContentValue:
                       allOf:
                         - $ref: "#/components/schemas/StructuredContent"
                       readOnly: true
-                    structuredContentId:
+                    structuredContentValueId:
                       format: int64
                       type: integer
                       writeOnly: true

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Schema.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Schema.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.vulcan.yaml.openapi;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +31,10 @@ public class Schema {
 		return _anyOfSchemas;
 	}
 
+	public List<String> getChildSchemas() {
+		return _childSchemas;
+	}
+
 	public String getDescription() {
 		return _description;
 	}
@@ -44,6 +49,10 @@ public class Schema {
 
 	public List<Schema> getOneOfSchemas() {
 		return _oneOfSchemas;
+	}
+
+	public String getParentSchema() {
+		return _parentSchema;
 	}
 
 	public Map<String, Schema> getPropertySchemas() {
@@ -66,6 +75,10 @@ public class Schema {
 		_anyOfSchemas = anyOfSchemas;
 	}
 
+	public void setChildSchemas(List<String> childSchemas) {
+		_childSchemas = childSchemas;
+	}
+
 	public void setDescription(String description) {
 		_description = description;
 	}
@@ -82,6 +95,10 @@ public class Schema {
 		_oneOfSchemas = oneOfSchemas;
 	}
 
+	public void setParentSchema(String parentSchema) {
+		_parentSchema = parentSchema;
+	}
+
 	public void setPropertySchemas(Map<String, Schema> propertySchemas) {
 		_propertySchemas = propertySchemas;
 	}
@@ -96,10 +113,12 @@ public class Schema {
 
 	private List<Schema> _allOfSchemas;
 	private List<Schema> _anyOfSchemas;
+	private List<String> _childSchemas = new ArrayList<>();
 	private String _description;
 	private String _format;
 	private Items _items;
 	private List<Schema> _oneOfSchemas;
+	private String _parentSchema;
 	private Map<String, Schema> _propertySchemas;
 	private String _reference;
 	private String _type;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Schema.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Schema.java
@@ -111,6 +111,18 @@ public class Schema {
 		_type = type;
 	}
 
+	public Schema _findAnyOfSchema() {
+		if (_propertySchemas != null) {
+			for (Schema schema : _propertySchemas.values()) {
+
+				if (schema.getAnyOfSchemas() != null) {
+					return this;
+				}
+			}
+		}
+		return null;
+	}
+
 	private List<Schema> _allOfSchemas;
 	private List<Schema> _anyOfSchemas;
 	private List<String> _childSchemas = new ArrayList<>();

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -29,6 +29,7 @@ import com.liferay.portal.vulcan.yaml.config.Application;
 import com.liferay.portal.vulcan.yaml.config.ConfigYAML;
 import com.liferay.portal.vulcan.yaml.openapi.Components;
 import com.liferay.portal.vulcan.yaml.openapi.Info;
+import com.liferay.portal.vulcan.yaml.openapi.Items;
 import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
 import com.liferay.portal.vulcan.yaml.openapi.Schema;
 
@@ -37,11 +38,15 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * @author Peter Shin
@@ -155,6 +160,10 @@ public class RESTBuilder {
 					context.put(
 						"schemaPath", CamelCaseUtil.fromCamelCase(schemaName));
 
+					_convertAnyOfSchemasToArray(schema);
+
+					_queueAnyOfSchemas(schemasMapsQueue, schema, schemaName);
+
 					_createDTOFile(context, schemaName, versionDirName);
 
 					schemasMapsQueue.add(schema.getPropertySchemas());
@@ -166,6 +175,40 @@ public class RESTBuilder {
 		FileUtil.deleteFiles(_configYAML.getImplDir(), _files);
 		FileUtil.deleteFiles(
 			_configYAML.getImplDir() + "/../resources/OSGI-INF/", _files);
+	}
+
+	private void _convertAnyOfSchemasToArray(Schema schema) {
+		Schema anyOfSchema = _findAnyOfSchema(schema);
+
+		if (anyOfSchema != null) {
+			anyOfSchema.setType("array");
+
+			Items items = new Items();
+
+			items.setType("object");
+
+			anyOfSchema.setItems(items);
+		}
+	}
+
+	private HashMap<String, Schema> _createAnyOfSchema(
+		Schema schema, String key) {
+
+		Map<String, Schema> propertySchemas = schema.getPropertySchemas();
+
+		Schema childSchema = propertySchemas.get(key);
+
+		if ((propertySchemas.size() == 1) &&
+			(childSchema.getPropertySchemas() != null)) {
+
+			schema.setPropertySchemas(childSchema.getPropertySchemas());
+		}
+
+		HashMap<String, Schema> anyOfSchemaMap = new HashMap<>();
+
+		anyOfSchemaMap.put(key, schema);
+
+		return anyOfSchemaMap;
 	}
 
 	private void _createApplicationFile(Map<String, Object> context)
@@ -341,6 +384,59 @@ public class RESTBuilder {
 			file,
 			FreeMarkerUtil.processTemplate(
 				_copyrightFileName, "resource_impl", context));
+	}
+
+	private Schema _findAnyOfSchema(Schema schema) {
+		return Stream.of(
+			schema.getPropertySchemas()
+		).map(
+			Map::values
+		).flatMap(
+			Collection::stream
+		).map(
+			Schema::_findAnyOfSchema
+		).filter(
+			Objects::nonNull
+		).findFirst(
+		).orElse(
+			null
+		);
+	}
+
+	private String _getAnyOfKey(Schema anyOfSchema) {
+		Map<String, Schema> propertySchemas = anyOfSchema.getPropertySchemas();
+
+		Set<String> keySet = propertySchemas.keySet();
+
+		return keySet.toArray(new String[0])[0];
+	}
+
+	private void _queueAnyOfSchemas(
+		Queue<Map<String, Schema>> schemasMapsQueue, Schema schema,
+		String schemaName) {
+
+		Map<String, Schema> propertySchemas = schema.getPropertySchemas();
+
+		if (propertySchemas != null) {
+			for (Schema childSchema : propertySchemas.values()) {
+				List<Schema> anyOfSchemas = childSchema.getAnyOfSchemas();
+
+				if (anyOfSchemas != null) {
+					for (Schema anyOfSchema : anyOfSchemas) {
+						anyOfSchema.setParentSchema(schemaName);
+
+						List<String> childSchemas = schema.getChildSchemas();
+
+						String key = _getAnyOfKey(anyOfSchema);
+
+						childSchemas.add(StringUtil.upperCaseFirstLetter(key));
+
+						schemasMapsQueue.add(
+							_createAnyOfSchema(anyOfSchema, key));
+					}
+				}
+			}
+		}
 	}
 
 	private final File _configDir;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -8,6 +8,11 @@ package ${configYAML.apiPackagePath}.dto.${versionDirName};
 
 import java.util.Date;
 
+<#if schema.childSchemas?has_content>
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+</#if>
+
 import javax.annotation.Generated;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -18,7 +23,21 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @Generated("")
 @XmlRootElement(name = "${schemaName}")
-public class ${schemaName} {
+<#if schema.childSchemas?has_content>
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+	include = JsonTypeInfo.As.PROPERTY,
+	property = "discriminator")
+@JsonSubTypes({
+	<#list schema.childSchemas as childSchema>
+		@JsonSubTypes.Type(value=${childSchema}.class, name = "${childSchema}")<#if childSchema_has_next>,</#if>
+	</#list>
+})
+</#if>
+public class ${schemaName}
+	<#if schema.parentSchema??>
+		extends ${schema.parentSchema}
+	</#if>
+	{
 
 	<#if schema.propertySchemas??>
 		<#list schema.propertySchemas?keys as propertySchemaName>


### PR DESCRIPTION
Ok, let's see... support for anyOf is a bit tricky because we need support for polymorphism... StructuredContent will have an array of values and those values can be Geo, Data, StructuredContentValue that will inherit from Values...

To serialize that (specially when submitting, rendering is easy because we know the class) we have to tell jackson how. We have 2 options: with @JsonSubTypes (that's why I modified the template) or customizing the objectMapper. But that is currently inside vulcan-impl and we would have to expose it and modify a static variable... :S

That's the first problem. The second and third one, that makes the code quite messy is because we have to 2 look ups, one when creating StructuredContent (we have to know that we have to do an array of Values, something that is inside the property values, and then the anyOfProperties of a child property) and another when creating Data (their parent is not the *value* property, is *values*).

One more elegant solution would be adding parentSchema to all properties and doing a two-step rendering, first calculate all the schemas and then a second loop to render all dtos. I tried to do in a step but, obviously, the dto is already created when I modify the parentSchema to add the array.

So feel free to add any suggestions (I'll be around in slack these days) and I can change the code to whatever you prefer :)

PD: I've added the generated code to showcase what it should render :)