### PR TITLE
LPS-90435 Support for tags

### DIFF
--- a/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-api/src/main/java/com/liferay/headless/collaboration/resource/v1_0/BlogPostingResource.java
@@ -79,6 +79,26 @@ public interface BlogPostingResource {
 	public BlogPosting putBlogPosting( @PathParam("blog-posting-id") Long blogPostingId , BlogPosting blogPosting ) throws Exception;
 
 	@GET
+	@Path("/blog-posting/{blog-posting-id}/categories")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Page<Long> getBlogPostingCategoriesPage( @PathParam("blog-posting-id") Long blogPostingId , @Context Pagination pagination ) throws Exception;
+
+	@Consumes("application/json")
+	@POST
+	@Path("/blog-posting/{blog-posting-id}/categories")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Response postBlogPostingCategories( @PathParam("blog-posting-id") Long blogPostingId , Long referenceId ) throws Exception;
+
+	@Consumes("application/json")
+	@POST
+	@Path("/blog-posting/{blog-posting-id}/categories/batch-create")
+	@Produces("application/json")
+	@RequiresScope("everything.write")
+	public Response postBlogPostingCategoriesBatchCreate( @PathParam("blog-posting-id") Long blogPostingId , Long referenceId ) throws Exception;
+
+	@GET
 	@Path("/content-space/{content-space-id}/blog-posting")
 	@Produces("application/json")
 	@RequiresScope("everything.read")

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/rest-openapi.yaml
@@ -187,6 +187,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/AggregateRating"
           description: ""
+      tags: ["AggregateRating"]
   "/blog-posting/{blog-posting-id}":
     delete:
       parameters:
@@ -201,6 +202,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["BlogPosting"]
     get:
       parameters:
         - in: path
@@ -216,6 +218,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
+      tags: ["BlogPosting"]
     put:
       parameters:
         - in: path
@@ -236,6 +239,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
+      tags: ["BlogPosting"]
   "/blog-posting/{blog-posting-id}/categories":
     get:
       parameters:
@@ -263,6 +267,7 @@ paths:
                   type: integer
                 type: array
           description: ""
+      tags: ["BlogPosting"]
     post:
       parameters:
         - in: path
@@ -285,6 +290,7 @@ paths:
                 format: int64
                 type: integer
           description: ""
+      tags: ["BlogPosting"]
   "/blog-posting/{blog-posting-id}/categories/batch-create":
     post:
       parameters:
@@ -308,6 +314,7 @@ paths:
                 format: int64
                 type: integer
           description: ""
+      tags: ["BlogPosting"]
   "/blog-posting/{blog-posting-id}/comment":
     get:
       parameters:
@@ -334,6 +341,7 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
+      tags: ["Comment"]
   "/comment/{comment-id}":
     get:
       parameters:
@@ -350,6 +358,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Comment"
           description: ""
+      tags: ["Comment"]
   "/comment/{comment-id}/comment":
     get:
       parameters:
@@ -376,6 +385,7 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
+      tags: ["Comment"]
   "/content-space/{content-space-id}/blog-posting":
     get:
       parameters:
@@ -402,6 +412,7 @@ paths:
                   $ref: "#/components/schemas/BlogPosting"
                 type: array
           description: ""
+      tags: ["BlogPosting"]
     post:
       parameters:
         - in: path
@@ -422,6 +433,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
+      tags: ["BlogPosting"]
   "/content-space/{content-space-id}/blog-posting/batch-create":
     post:
       parameters:
@@ -443,6 +455,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/BlogPosting"
           description: ""
+      tags: ["BlogPosting"]
   "/creator/{creator-id}":
     get:
       parameters:
@@ -459,6 +472,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Creator"
           description: ""
+      tags: ["Creator"]
   "/image-object-repository/{image-object-repository-id}":
     get:
       parameters:
@@ -475,6 +489,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ImageObjectRepository"
           description: ""
+      tags: ["ImageObjectRepository"]
   "/image-object-repository/{image-object-repository-id}/image-object":
     get:
       parameters:
@@ -501,6 +516,7 @@ paths:
                   $ref: "#/components/schemas/ImageObject"
                 type: array
           description: ""
+      tags: ["ImageObject"]
     post:
       parameters:
         - in: path
@@ -521,6 +537,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ImageObject"
           description: ""
+      tags: ["ImageObject"]
   "/image-object-repository/{image-object-repository-id}/image-object/batch-create":
     post:
       parameters:
@@ -542,6 +559,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ImageObject"
           description: ""
+      tags: ["ImageObject"]
   "/image-object/{image-object-id}":
     delete:
       parameters:
@@ -556,6 +574,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["ImageObject"]
     get:
       parameters:
         - in: path
@@ -571,3 +590,4 @@ paths:
               schema:
                 $ref: "#/components/schemas/ImageObject"
           description: ""
+      tags: ["ImageObject"]

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-impl/src/main/java/com/liferay/headless/collaboration/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -52,11 +52,39 @@ public abstract class BaseBlogPostingResourceImpl
 	}
 
 	@Override
+	public Page<Long> getBlogPostingCategoriesPage(
+			Long blogPostingId, Pagination pagination)
+		throws Exception {
+
+		return new Page<>();
+	}
+
+	@Override
 	public Page<BlogPosting> getContentSpaceBlogPostingPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public Response postBlogPostingCategories(
+			Long blogPostingId, Long referenceId)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
+	}
+
+	@Override
+	public Response postBlogPostingCategoriesBatchCreate(
+			Long blogPostingId, Long referenceId)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-api/src/main/java/com/liferay/headless/document/library/resource/v1_0/DocumentResource.java
@@ -70,6 +70,26 @@ public interface DocumentResource {
 	public Document getDocument( @PathParam("document-id") Long documentId ) throws Exception;
 
 	@GET
+	@Path("/document/{document-id}/categories")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Page<Long> getDocumentCategoriesPage( @PathParam("document-id") Long documentId , @Context Pagination pagination ) throws Exception;
+
+	@Consumes("application/json")
+	@POST
+	@Path("/document/{document-id}/categories")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Response postDocumentCategories( @PathParam("document-id") Long documentId , Long referenceId ) throws Exception;
+
+	@Consumes("application/json")
+	@POST
+	@Path("/document/{document-id}/categories/batch-create")
+	@Produces("application/json")
+	@RequiresScope("everything.write")
+	public Response postDocumentCategoriesBatchCreate( @PathParam("document-id") Long documentId , Long referenceId ) throws Exception;
+
+	@GET
 	@Path("/documents-repository/{documents-repository-id}/document")
 	@Produces("application/json")
 	@RequiresScope("everything.read")

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/rest-openapi.yaml
@@ -168,6 +168,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Creator"
           description: ""
+      tags: ["Creator"]
   "/document/{document-id}":
     delete:
       parameters:
@@ -182,6 +183,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["Document"]
     get:
       parameters:
         - in: path
@@ -197,6 +199,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
+      tags: ["Document"]
   "/document/{document-id}/categories":
     get:
       parameters:
@@ -224,6 +227,7 @@ paths:
                   type: integer
                 type: array
           description: ""
+      tags: ["Document"]
     post:
       parameters:
         - in: path
@@ -246,6 +250,7 @@ paths:
                 format: int64
                 type: integer
           description: ""
+      tags: ["Document"]
   "/document/{document-id}/categories/batch-create":
     post:
       parameters:
@@ -269,6 +274,7 @@ paths:
                 format: int64
                 type: integer
           description: ""
+      tags: ["Document"]
   "/document/{document-id}/comment":
     get:
       parameters:
@@ -295,6 +301,7 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
+      tags: ["Comment"]
   "/documents-repository/{id}":
     get:
       parameters:
@@ -311,6 +318,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
+      tags: ["Folder"]
   "/documents-repository/{documents-repository-id}/document":
     get:
       parameters:
@@ -337,6 +345,7 @@ paths:
                   $ref: "#/components/schemas/Document"
                 type: array
           description: ""
+      tags: ["Document"]
     post:
       parameters:
         - in: path
@@ -357,6 +366,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
+      tags: ["Document"]
   "/documents-repository/{documents-repository-id}/document/batch-create":
     post:
       parameters:
@@ -378,6 +388,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
+      tags: ["Document"]
   "/documents-repository/{documents-repository-id}/folder":
     get:
       parameters:
@@ -404,6 +415,7 @@ paths:
                   $ref: "#/components/schemas/Folder"
                 type: array
           description: ""
+      tags: ["Folder"]
     post:
       parameters:
         - in: path
@@ -424,6 +436,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
+      tags: ["Folder"]
   "/documents-repository/{documents-repository-id}/folder/batch-create":
     post:
       parameters:
@@ -445,6 +458,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
+      tags: ["Folder"]
   "/folder/{folder-id}":
     delete:
       parameters:
@@ -459,6 +473,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["Folder"]
     get:
       parameters:
         - in: path
@@ -474,6 +489,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
+      tags: ["Folder"]
     put:
       parameters:
         - in: path
@@ -494,6 +510,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
+      tags: ["Folder"]
   "/folder/{folder-id}/document":
     get:
       parameters:
@@ -520,6 +537,7 @@ paths:
                   $ref: "#/components/schemas/Document"
                 type: array
           description: ""
+      tags: ["Document"]
     post:
       parameters:
         - in: path
@@ -546,6 +564,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
+      tags: ["Document"]
   "/folder/{folder-id}/document/batch-create":
     post:
       parameters:
@@ -573,6 +592,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Document"
           description: ""
+      tags: ["Document"]
   "/folder/{folder-id}/folder":
     get:
       parameters:
@@ -599,6 +619,7 @@ paths:
                   $ref: "#/components/schemas/Folder"
                 type: array
           description: ""
+      tags: ["Folder"]
     post:
       parameters:
         - in: path
@@ -619,6 +640,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
+      tags: ["Folder"]
   "/folder/{folder-id}/folder/batch-create":
     post:
       parameters:
@@ -640,3 +662,4 @@ paths:
               schema:
                 $ref: "#/components/schemas/Folder"
           description: ""
+      tags: ["Folder"]

--- a/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-impl/src/main/java/com/liferay/headless/document/library/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -52,6 +52,14 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 	}
 
 	@Override
+	public Page<Long> getDocumentCategoriesPage(
+			Long documentId, Pagination pagination)
+		throws Exception {
+
+		return new Page<>();
+	}
+
+	@Override
 	public Page<Document> getDocumentsRepositoryDocumentPage(
 			Long documentsRepositoryId, Pagination pagination)
 		throws Exception {
@@ -65,6 +73,25 @@ public abstract class BaseDocumentResourceImpl implements DocumentResource {
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public Response postDocumentCategories(Long documentId, Long referenceId)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
+	}
+
+	@Override
+	public Response postDocumentCategoriesBatchCreate(
+			Long documentId, Long referenceId)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -335,6 +335,7 @@ paths:
                   $ref: "#/components/schemas/Form"
                 type: array
           description: ""
+      tags: ["Form"]
   "/content-space/{content-space-id}/form-structures":
     get:
       parameters:
@@ -361,6 +362,7 @@ paths:
                   $ref: "#/components/schemas/FormStructure"
                 type: array
           description: ""
+      tags: ["FormStructure"]
   "/creator/{creator-id}":
     get:
       parameters:
@@ -377,6 +379,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Creator"
           description: ""
+      tags: ["Creator"]
   "/form-document/{form-document-id}":
     delete:
       parameters:
@@ -391,6 +394,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["FormDocument"]
     get:
       parameters:
         - in: path
@@ -406,6 +410,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormDocument"
           description: ""
+      tags: ["FormDocument"]
   "/form-record/{form-record-id}":
     get:
       parameters:
@@ -422,6 +427,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormRecord"
           description: ""
+      tags: ["FormRecord"]
     put:
       parameters:
         - in: path
@@ -446,6 +452,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormRecord"
           description: ""
+      tags: ["FormRecord"]
   "/form-structures/{form-structures-id}":
     get:
       parameters:
@@ -462,6 +469,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormStructure"
           description: ""
+      tags: ["FormStructure"]
   "/form/{form-id}":
     get:
       parameters:
@@ -478,6 +486,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Form"
           description: ""
+      tags: ["Form"]
   "/form/{form-id}/evaluate-context":
     post:
       parameters:
@@ -503,6 +512,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Form"
           description: ""
+      tags: ["Form"]
   "/form/{form-id}/fetch-latest-draft":
     get:
       parameters:
@@ -519,6 +529,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Form"
           description: ""
+      tags: ["Form"]
   "/form/{form-id}/form-record":
     get:
       parameters:
@@ -545,6 +556,7 @@ paths:
                   $ref: "#/components/schemas/FormRecord"
                 type: array
           description: ""
+      tags: ["FormRecord"]
     post:
       parameters:
         - in: path
@@ -569,6 +581,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormRecord"
           description: ""
+      tags: ["FormRecord"]
   "/form/{form-id}/form-record/batch-create":
     post:
       parameters:
@@ -594,6 +607,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FormRecord"
           description: ""
+      tags: ["FormRecord"]
   "/form/{form-id}/upload-file":
     post:
       parameters:
@@ -615,3 +629,4 @@ paths:
               schema:
                 $ref: "#/components/schemas/Form"
           description: ""
+      tags: ["Form"]

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/CategoryResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/CategoryResource.java
@@ -63,6 +63,12 @@ import javax.ws.rs.core.Response;
 @Path("/v1.0")
 public interface CategoryResource {
 
+	@DELETE
+	@Path("/categories/{categories-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Response deleteCategories( @PathParam("categories-id") Long categoriesId ) throws Exception;
+
 	@GET
 	@Path("/categories/{categories-id}")
 	@Produces("application/json")

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/KeywordResource.java
@@ -83,6 +83,12 @@ public interface KeywordResource {
 	@RequiresScope("everything.write")
 	public Keyword postContentSpaceKeywordsBatchCreate( @PathParam("content-space-id") Long contentSpaceId , Keyword keyword ) throws Exception;
 
+	@DELETE
+	@Path("/keywords/{keywords-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Response deleteKeywords( @PathParam("keywords-id") Long keywordsId ) throws Exception;
+
 	@GET
 	@Path("/keywords/{keywords-id}")
 	@Produces("application/json")

--- a/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/VocabularyResource.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-api/src/main/java/com/liferay/headless/foundation/resource/v1_0/VocabularyResource.java
@@ -83,6 +83,12 @@ public interface VocabularyResource {
 	@RequiresScope("everything.write")
 	public Vocabulary postContentSpaceVocabulariesBatchCreate( @PathParam("content-space-id") Long contentSpaceId , Vocabulary vocabulary ) throws Exception;
 
+	@DELETE
+	@Path("/vocabularies/{vocabularies-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Response deleteVocabularies( @PathParam("vocabularies-id") Long vocabulariesId ) throws Exception;
+
 	@GET
 	@Path("/vocabularies/{vocabularies-id}")
 	@Produces("application/json")

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/rest-openapi.yaml
@@ -482,6 +482,7 @@ paths:
                   $ref: "#/components/schemas/PostalAddress"
                 type: array
           description: ""
+      tags: ["Address"]
   "/addresses/{addresses-id}":
     get:
       parameters:
@@ -498,6 +499,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/PostalAddress"
           description: ""
+      tags: ["Address"]
   "/categories/{categories-id}":
     delete:
       parameters:
@@ -512,6 +514,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["Category"]
     get:
       parameters:
         - in: path
@@ -527,6 +530,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
+      tags: ["Category"]
     put:
       parameters:
         - in: path
@@ -547,6 +551,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
+      tags: ["Category"]
   "/categories/{categories-id}/categories":
     get:
       parameters:
@@ -573,6 +578,7 @@ paths:
                   $ref: "#/components/schemas/Category"
                 type: array
           description: ""
+      tags: ["Category"]
     post:
       parameters:
         - in: path
@@ -593,6 +599,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
+      tags: ["Category"]
   "/categories/{categories-id}/categories/batch-create":
     post:
       parameters:
@@ -614,6 +621,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
+      tags: ["Category"]
   "/content-space/{content-space-id}/keywords":
     get:
       parameters:
@@ -640,6 +648,7 @@ paths:
                   $ref: "#/components/schemas/Keyword"
                 type: array
           description: ""
+      tags: ["Keyword"]
     post:
       parameters:
         - in: path
@@ -681,6 +690,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Keyword"
           description: ""
+      tags: ["Keyword"]
   "/content-space/{content-space-id}/vocabularies":
     get:
       parameters:
@@ -707,6 +717,7 @@ paths:
                   $ref: "#/components/schemas/Vocabulary"
                 type: array
           description: ""
+      tags: ["Vocabulary"]
     post:
       parameters:
         - in: path
@@ -727,6 +738,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vocabulary"
           description: ""
+      tags: ["Vocabulary"]
   "/content-space/{content-space-id}/vocabularies/batch-create":
     post:
       parameters:
@@ -748,6 +760,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vocabulary"
           description: ""
+      tags: ["Vocabulary"]
   "/emails":
     get:
       parameters:
@@ -773,6 +786,7 @@ paths:
                   $ref: "#/components/schemas/Email"
                 type: array
           description: ""
+      tags: ["Email"]
   "/emails/{emails-id}":
     get:
       parameters:
@@ -789,6 +803,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Email"
           description: ""
+      tags: ["Email"]
   "/keywords/{keywords-id}":
     delete:
       parameters:
@@ -803,6 +818,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["Keyword"]
     get:
       parameters:
         - in: path
@@ -818,6 +834,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Keyword"
           description: ""
+      tags: ["Keyword"]
     put:
       parameters:
         - in: path
@@ -838,6 +855,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Keyword"
           description: ""
+      tags: ["Keyword"]
   "/my-user-account":
     get:
       parameters:
@@ -858,6 +876,7 @@ paths:
                   $ref: "#/components/schemas/UserAccount"
                 type: array
           description: ""
+      tags: ["UserAccount"]
   "/my-user-account/{my-user-account-id}":
     get:
       parameters:
@@ -874,6 +893,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
+      tags: ["UserAccount"]
   "/my-user-account/{my-user-account-id}/organization":
     get:
       parameters:
@@ -900,6 +920,7 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
+      tags: ["Organization"]
   "/my-user-account/{my-user-account-id}/roles":
     get:
       parameters:
@@ -926,6 +947,7 @@ paths:
                   $ref: "#/components/schemas/Role"
                 type: array
           description: ""
+      tags: ["Role"]
   "/organization":
     get:
       parameters:
@@ -946,6 +968,7 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
+      tags: ["Organization"]
   "/organization/{organization-id}":
     get:
       parameters:
@@ -962,6 +985,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
           description: ""
+      tags: ["Organization"]
   "/organization/{organization-id}/organization":
     get:
       parameters:
@@ -988,6 +1012,7 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
+      tags: ["Organization"]
   "/organization/{organization-id}/user-account":
     get:
       parameters:
@@ -1014,6 +1039,7 @@ paths:
                   $ref: "#/components/schemas/UserAccount"
                 type: array
           description: ""
+      tags: ["UserAccount"]
   "/phones":
     get:
       parameters:
@@ -1039,6 +1065,7 @@ paths:
                   $ref: "#/components/schemas/Phone"
                 type: array
           description: ""
+      tags: ["Phone"]
   "/phones/{phones-id}":
     get:
       parameters:
@@ -1055,6 +1082,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Phone"
           description: ""
+      tags: ["Phone"]
   "/roles":
     get:
       parameters:
@@ -1075,6 +1103,7 @@ paths:
                   $ref: "#/components/schemas/Role"
                 type: array
           description: ""
+      tags: ["Role"]
   "/roles/{roles-id}":
     get:
       parameters:
@@ -1091,6 +1120,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Role"
           description: ""
+      tags: ["Role"]
   "/user-account":
     get:
       parameters:
@@ -1115,6 +1145,7 @@ paths:
                   $ref: "#/components/schemas/UserAccount"
                 type: array
           description: ""
+      tags: ["UserAccount"]
     post:
       parameters: []
       requestBody:
@@ -1129,6 +1160,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
+      tags: ["UserAccount"]
   "/user-account/batch-create":
     post:
       parameters: []
@@ -1144,6 +1176,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
+      tags: ["UserAccount"]
   "/user-account/{user-account-id}":
     delete:
       parameters:
@@ -1158,6 +1191,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["UserAccount"]
     get:
       parameters:
         - in: path
@@ -1173,6 +1207,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
+      tags: ["UserAccount"]
     put:
       parameters:
         - in: path
@@ -1193,6 +1228,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserAccount"
           description: ""
+      tags: ["UserAccount"]
   "/user-account/{user-account-id}/organization":
     get:
       parameters:
@@ -1219,6 +1255,7 @@ paths:
                   $ref: "#/components/schemas/Organization"
                 type: array
           description: ""
+      tags: ["Organization"]
   "/user-account/{user-account-id}/roles":
     get:
       parameters:
@@ -1245,6 +1282,7 @@ paths:
                   $ref: "#/components/schemas/Role"
                 type: array
           description: ""
+      tags: ["Role"]
   "/vocabularies/{vocabularies-id}":
     delete:
       parameters:
@@ -1259,6 +1297,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["Vocabulary"]
     get:
       parameters:
         - in: path
@@ -1274,6 +1313,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vocabulary"
           description: ""
+      tags: ["Vocabulary"]
     put:
       parameters:
         - in: path
@@ -1294,6 +1334,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Vocabulary"
           description: ""
+      tags: ["Vocabulary"]
   "/vocabularies/{vocabularies-id}/categories":
     get:
       parameters:
@@ -1320,6 +1361,7 @@ paths:
                   $ref: "#/components/schemas/Category"
                 type: array
           description: ""
+      tags: ["Category"]
     post:
       parameters:
         - in: path
@@ -1340,6 +1382,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
+      tags: ["Category"]
   "/vocabularies/{vocabularies-id}/categories/batch-create":
     post:
       parameters:
@@ -1361,6 +1404,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Category"
           description: ""
+      tags: ["Category"]
   "/web-site/{web-site-id}/user-account":
     get:
       parameters:
@@ -1387,6 +1431,7 @@ paths:
                   $ref: "#/components/schemas/UserAccount"
                 type: array
           description: ""
+      tags: ["UserAccount"]
   "/web-urls":
     get:
       parameters:
@@ -1412,6 +1457,7 @@ paths:
                   $ref: "#/components/schemas/WebUrl"
                 type: array
           description: ""
+      tags: ["WebUrl"]
   "/web-urls/{web-urls-id}":
     get:
       parameters:
@@ -1428,3 +1474,4 @@ paths:
               schema:
                 $ref: "#/components/schemas/WebUrl"
           description: ""
+      tags: ["WebUrl"]

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -39,6 +39,13 @@ import javax.ws.rs.core.Response;
 public abstract class BaseCategoryResourceImpl implements CategoryResource {
 
 	@Override
+	public Response deleteCategories(Long categoriesId) throws Exception {
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
+	}
+
+	@Override
 	public Category getCategories(Long categoriesId) throws Exception {
 		return new Category();
 	}

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -39,6 +39,13 @@ import javax.ws.rs.core.Response;
 public abstract class BaseKeywordResourceImpl implements KeywordResource {
 
 	@Override
+	public Response deleteKeywords(Long keywordsId) throws Exception {
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
+	}
+
+	@Override
 	public Page<Keyword> getContentSpaceKeywordsPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {

--- a/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-impl/src/main/java/com/liferay/headless/foundation/internal/resource/v1_0/BaseVocabularyResourceImpl.java
@@ -39,6 +39,13 @@ import javax.ws.rs.core.Response;
 public abstract class BaseVocabularyResourceImpl implements VocabularyResource {
 
 	@Override
+	public Response deleteVocabularies(Long vocabulariesId) throws Exception {
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
+	}
+
+	@Override
 	public Page<Vocabulary> getContentSpaceVocabulariesPage(
 			Long contentSpaceId, Pagination pagination)
 		throws Exception {

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-api/src/main/java/com/liferay/headless/web/experience/resource/v1_0/StructuredContentResource.java
@@ -92,6 +92,12 @@ public interface StructuredContentResource {
 	@RequiresScope("everything.write")
 	public StructuredContent postContentSpaceStructuredContentBatchCreate( @PathParam("content-space-id") Long contentSpaceId , StructuredContent structuredContent ) throws Exception;
 
+	@GET
+	@Path("/content-structures/{content-structures-id}")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public ContentStructure getContentStructures( @PathParam("content-structures-id") Long contentStructuresId ) throws Exception;
+
 	@DELETE
 	@Path("/structured-content/{structured-content-id}")
 	@Produces("application/json")
@@ -110,5 +116,25 @@ public interface StructuredContentResource {
 	@Produces("application/json")
 	@RequiresScope("everything.read")
 	public StructuredContent putStructuredContent( @PathParam("structured-content-id") Long structuredContentId , StructuredContent structuredContent ) throws Exception;
+
+	@GET
+	@Path("/structured-content/{structured-content-id}/categories")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Page<Long> getStructuredContentCategoriesPage( @PathParam("structured-content-id") Long structuredContentId , @Context Pagination pagination ) throws Exception;
+
+	@Consumes("application/json")
+	@POST
+	@Path("/structured-content/{structured-content-id}/categories")
+	@Produces("application/json")
+	@RequiresScope("everything.read")
+	public Response postStructuredContentCategories( @PathParam("structured-content-id") Long structuredContentId , Long referenceId ) throws Exception;
+
+	@Consumes("application/json")
+	@POST
+	@Path("/structured-content/{structured-content-id}/categories/batch-create")
+	@Produces("application/json")
+	@RequiresScope("everything.write")
+	public Response postStructuredContentCategoriesBatchCreate( @PathParam("structured-content-id") Long structuredContentId , Long referenceId ) throws Exception;
 
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/rest-openapi.yaml
@@ -289,6 +289,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/AggregateRating"
           description: ""
+      tags: ["AggregateRating"]
   "/comment/{comment-id}":
     get:
       parameters:
@@ -305,6 +306,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Comment"
           description: ""
+      tags: ["Comment"]
   "/comment/{comment-id}/comment":
     get:
       parameters:
@@ -331,6 +333,7 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
+      tags: ["Comment"]
   "/content-document/{content-document-id}":
     delete:
       parameters:
@@ -345,6 +348,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["ContentDocument"]
     get:
       parameters:
         - in: path
@@ -360,6 +364,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ContentDocument"
           description: ""
+      tags: ["ContentDocument"]
   "/content-space/{content-space-id}/content-structures":
     get:
       parameters:
@@ -386,6 +391,7 @@ paths:
                   $ref: "#/components/schemas/ContentStructure"
                 type: array
           description: ""
+      tags: ["ContentStructure"]
   "/content-space/{content-space-id}/content-structure/{content-structure-id}/structured-content":
     get:
       parameters:
@@ -430,6 +436,7 @@ paths:
                   $ref: "#/components/schemas/StructuredContent"
                 type: array
           description: ""
+      tags: ["StructuredContent"]
   "/content-space/{content-space-id}/structured-content":
     get:
       parameters:
@@ -468,6 +475,7 @@ paths:
                   $ref: "#/components/schemas/StructuredContent"
                 type: array
           description: ""
+      tags: ["StructuredContent"]
     patch:
       parameters:
         - in: path
@@ -492,6 +500,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
+      tags: ["StructuredContent"]
     post:
       parameters:
         - in: path
@@ -516,6 +525,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
+      tags: ["StructuredContent"]
   "/content-space/{content-space-id}/structured-content/batch-create":
     post:
       parameters:
@@ -541,6 +551,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
+      tags: ["StructuredContent"]
   "/content-structures/{content-structures-id}":
     get:
       parameters:
@@ -557,6 +568,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ContentStructure"
           description: ""
+      tags: ["StructuredContent"]
   "/creator/{creator-id}":
     get:
       parameters:
@@ -573,6 +585,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Creator"
           description: ""
+      tags: ["Creator"]
   "/structured-content/{structured-content-id}":
     delete:
       parameters:
@@ -587,6 +600,7 @@ paths:
           content:
             application/json: {}
           description: ""
+      tags: ["StructuredContent"]
     get:
       parameters:
         - in: path
@@ -606,6 +620,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
+      tags: ["StructuredContent"]
     put:
       parameters:
         - in: path
@@ -630,6 +645,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/StructuredContent"
           description: ""
+      tags: ["StructuredContent"]
   "/structured-content/{structured-content-id}/categories":
     get:
       parameters:
@@ -657,6 +673,7 @@ paths:
                   type: integer
                 type: array
           description: ""
+      tags: ["StructuredContent"]
     post:
       parameters:
         - in: path
@@ -679,6 +696,7 @@ paths:
                 format: int64
                 type: integer
           description: ""
+      tags: ["StructuredContent"]
   "/structured-content/{structured-content-id}/categories/batch-create":
     post:
       parameters:
@@ -702,6 +720,7 @@ paths:
                 format: int64
                 type: integer
           description: ""
+      tags: ["StructuredContent"]
   "/structured-content/{structured-content-id}/comment":
     get:
       parameters:
@@ -728,3 +747,4 @@ paths:
                   $ref: "#/components/schemas/Comment"
                 type: array
           description: ""
+      tags: ["Comment"]

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-impl/src/main/java/com/liferay/headless/web/experience/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.web.experience.internal.resource.v1_0;
 
+import com.liferay.headless.web.experience.dto.v1_0.ContentStructure;
 import com.liferay.headless.web.experience.dto.v1_0.StructuredContent;
 import com.liferay.headless.web.experience.resource.v1_0.StructuredContentResource;
 import com.liferay.petra.function.UnsafeFunction;
@@ -69,10 +70,25 @@ public abstract class BaseStructuredContentResourceImpl
 	}
 
 	@Override
+	public ContentStructure getContentStructures(Long contentStructuresId)
+		throws Exception {
+
+		return new ContentStructure();
+	}
+
+	@Override
 	public StructuredContent getStructuredContent(Long structuredContentId)
 		throws Exception {
 
 		return new StructuredContent();
+	}
+
+	@Override
+	public Page<Long> getStructuredContentCategoriesPage(
+			Long structuredContentId, Pagination pagination)
+		throws Exception {
+
+		return new Page<>();
 	}
 
 	@Override
@@ -97,6 +113,26 @@ public abstract class BaseStructuredContentResourceImpl
 		throws Exception {
 
 		return new StructuredContent();
+	}
+
+	@Override
+	public Response postStructuredContentCategories(
+			Long structuredContentId, Long referenceId)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
+	}
+
+	@Override
+	public Response postStructuredContentCategoriesBatchCreate(
+			Long structuredContentId, Long referenceId)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-workflow/headless-workflow-impl/rest-openapi.yaml
@@ -118,6 +118,7 @@ paths:
                   $ref: "#/components/schemas/WorkflowTask"
                 type: array
           description: ""
+      tags: ["WorkflowTask"]
   "/workflow-logs/{workflow-logs-id}":
     get:
       parameters:
@@ -134,6 +135,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowLog"
           description: ""
+      tags: ["WorkflowLog"]
   "/workflow-tasks":
     get:
       parameters:
@@ -159,6 +161,7 @@ paths:
                   $ref: "#/components/schemas/WorkflowTask"
                 type: array
           description: ""
+      tags: ["WorkflowTask"]
   "/workflow-tasks/{workflow-tasks-id}":
     get:
       parameters:
@@ -175,6 +178,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
+      tags: ["WorkflowTask"]
   "/workflow-tasks/{workflow-tasks-id}/assign-to-me":
     post:
       parameters:
@@ -196,6 +200,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
+      tags: ["WorkflowTask"]
   "/workflow-tasks/{workflow-tasks-id}/assign-to-user":
     post:
       parameters:
@@ -217,6 +222,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
+      tags: ["WorkflowTask"]
   "/workflow-tasks/{workflow-tasks-id}/change-transition":
     post:
       parameters:
@@ -238,6 +244,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
+      tags: ["WorkflowTask"]
   "/workflow-tasks/{workflow-tasks-id}/update-due-date":
     post:
       parameters:
@@ -259,6 +266,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkflowTask"
           description: ""
+      tags: ["WorkflowTask"]
   "/workflow-tasks/{workflow-tasks-id}/workflow-logs":
     get:
       parameters:
@@ -285,3 +293,4 @@ paths:
                   $ref: "#/components/schemas/WorkflowLog"
                 type: array
           description: ""
+      tags: ["WorkflowLog"]

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Operation.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/Operation.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.vulcan.yaml.openapi;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +39,10 @@ public class Operation {
 		return _responses;
 	}
 
+	public List<String> getTags() {
+		return _tags;
+	}
+
 	public void setOperationId(String operationId) {
 		_operationId = operationId;
 	}
@@ -54,9 +59,14 @@ public class Operation {
 		_responses = responses;
 	}
 
+	public void setTags(List<String> tags) {
+		_tags = tags;
+	}
+
 	private String _operationId;
 	private List<Parameter> _parameters;
 	private RequestBody _requestBody;
 	private Map<String, Response> _responses;
+	private List<String> _tags = new ArrayList<>();
 
 }

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/JavaTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/JavaTool.java
@@ -110,7 +110,9 @@ public class JavaTool {
 					String methodName = _getMethodName(
 						operation, path, returnType, schemaName);
 
-					if (_isSchemaMethod(schemaName, methodName, returnType)) {
+					if (_isSchemaMethod(
+							schemaName, operation.getTags(), returnType)) {
+
 						JavaSignature javaSignature = new JavaSignature(
 							path, pathItem, operation,
 							_getJavaParameters(operation), methodName,
@@ -327,6 +329,10 @@ public class JavaTool {
 					String parameterName = StringUtil.lowerCaseFirstLetter(
 						schemaName);
 
+					if (StringUtil.equals(schemaName, "Long")) {
+						parameterName = "referenceId";
+					}
+
 					javaParameters.add(
 						new JavaParameter(
 							Collections.emptySet(), parameterName, schemaName));
@@ -540,9 +546,9 @@ public class JavaTool {
 	}
 
 	private boolean _isSchemaMethod(
-		String schemaName, String methodName, String returnType) {
+		String schemaName, List<String> tags, String returnType) {
 
-		if (returnType.equals(schemaName) || methodName.endsWith(schemaName) ||
+		if (returnType.equals(schemaName) || tags.contains(schemaName) ||
 			((returnType.length() == schemaName.length() + 6) &&
 			 returnType.startsWith("Page<") && returnType.endsWith(">") &&
 			 returnType.regionMatches(5, schemaName, 0, schemaName.length()))) {


### PR DESCRIPTION
Hi Peter!

We have an issue with the paths (should be in plural instead of singular, like structured-contents) and with that change it makes harder to detect the methods that belong to a resource (specially in the Delete operation) but it happens also in routes like /blog-posting/{blog-posting-id}/categories (that belongs to BlogPosting).

The way of grouping requests in OpenAPI is using tags: "Tags can be used for logical grouping of operations by resources or any other qualifier." 

So I have use those to group APIs in resources. Only Delete and other operations are needed but I've added them all 1) because consistency and 2) the swagger editor uses them to group the requests and it's more usable (before that appeared them all in an unclassified category)

I've added the change in java code, just rebased preston PR :) 

I had to rename the long field because of the "Long long". It was an API that was not being generated before.

PD: I can rebase the other one of anyOf too