### PR TITLE
LRCI-844 Skip dxp projects by default, check build profile before deploying osgi apps

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6014,15 +6014,8 @@ go</echo>
 											</sequential>
 										</for>
 
-										<local name="deploy.build.profile" />
-
-										<condition else="portal" property="deploy.build.profile" value="${build.profile}">
-											<equals arg1="${build.profile}" arg2="dxp" />
-										</condition>
-
 										<gradle-execute dir="@{app.dir}" task="deploy">
 											<arg value="clean" />
-											<arg value="-Dbuild.profile=${deploy.build.profile}" />
 										</gradle-execute>
 
 										<for param="module.dir.path">

--- a/build-test.xml
+++ b/build-test.xml
@@ -5927,14 +5927,18 @@ go</echo>
 							<antelope:trim />
 						</antelope:stringutil>
 
+						<local name="app.dir.includes" />
+
+						<condition else="apps/${osgi.app.name}" property="app.dir.includes" value="apps/${osgi.app.name},dxp/apps/${osgi.app.name}">
+							<equals arg1="${build.propfile}" arg2="dxp" />
+						</condition>
+
 						<for param="app.dir">
 							<path>
 								<dirset
 									dir="modules"
-								>
-									<include name="apps/${osgi.app.name}" />
-									<include name="dxp/apps/${osgi.app.name}" />
-								</dirset>
+									includes="${app.dir.includes}"
+								/>
 							</path>
 							<sequential>
 								<local name="Liferay-Releng-App-Title" />

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferaySettingsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferaySettingsPlugin.java
@@ -147,6 +147,31 @@ public class LiferaySettingsPlugin implements Plugin<Settings> {
 		return ProjectDirType.UNKNOWN;
 	}
 
+	private boolean _includeDXPProjects(
+		String buildProfile, Set<String> buildProfileFileNames,
+		Path projectPathRootDirPath) {
+
+		if ((buildProfile == null) && (buildProfileFileNames == null)) {
+			File portalRootDir = GradleUtil.getRootDir(
+				projectPathRootDirPath.toFile(), "portal-impl");
+
+			if (portalRootDir == null) {
+				return false;
+			}
+
+			File buildProfileDXPPropertiesFile = new File(
+				portalRootDir, "build.profile-dxp.properties");
+
+			if (!buildProfileDXPPropertiesFile.exists()) {
+				return false;
+			}
+
+			return true;
+		}
+
+		return Objects.equals(buildProfile, "dxp");
+	}
+
 	private void _includeProject(
 		Settings settings, Path projectDirPath, Path projectPathRootDirPath,
 		String projectPathPrefix) {
@@ -186,6 +211,9 @@ public class LiferaySettingsPlugin implements Plugin<Settings> {
 		final Set<ProjectDirType> excludedProjectDirTypes = _getFlags(
 			"build.exclude.", ProjectDirType.class);
 
+		final boolean includeDXPProjects = _includeDXPProjects(
+			buildProfile, buildProfileFileNames, projectPathRootDirPath);
+
 		Files.walkFileTree(
 			projectPathRootDirPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS),
 			10,
@@ -203,9 +231,7 @@ public class LiferaySettingsPlugin implements Plugin<Settings> {
 						return FileVisitResult.SKIP_SUBTREE;
 					}
 
-					if ((buildProfileFileNames != null) &&
-						!Objects.equals(buildProfile, "dxp")) {
-
+					if (!includeDXPProjects) {
 						Path dxpPath = projectPathRootDirPath.resolve("dxp");
 
 						if (dirPath.equals(dxpPath)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-844

I prepared the backport branches here:
`7.0.x`: https://github.com/yichenroy/liferay-portal-ee/commits/LRCI-844-skip-dxp-project-by-default-fix-subrepo-test-7.0.x
`7.1.x`: https://github.com/yichenroy/liferay-portal-ee/commits/LRCI-844-skip-dxp-project-by-default-fix-subrepo-test-7.1.x
`7.2.x`: https://github.com/yichenroy/liferay-portal-ee/commits/LRCI-844-skip-dxp-project-by-default-fix-subrepo-test-7.2.x 