### PR TITLE
LPS-110835 Match JSP compiler resource path

### DIFF
--- a/modules/sdk/ant-bnd/src/main/java/com/liferay/ant/bnd/jsp/JspAnalyzerPlugin.java
+++ b/modules/sdk/ant-bnd/src/main/java/com/liferay/ant/bnd/jsp/JspAnalyzerPlugin.java
@@ -328,7 +328,8 @@ public class JspAnalyzerPlugin implements AnalyzerPlugin {
 			// Check to see if the JAR provides this TLD itself which would
 			// indicate that it already has access to the required classes
 
-			if (containsTLD(analyzer, analyzer.getJar(), "META-INF", uri) ||
+			if (containsTLD(
+					analyzer, analyzer.getJar(), "META-INF/resources", uri) ||
 				containsTLD(analyzer, analyzer.getJar(), "WEB-INF/tld", uri) ||
 				containsTLDInBundleClassPath(analyzer, "META-INF", uri)) {
 


### PR DESCRIPTION
Hi Peter, 
this PR allows to have tld private to the module by making both the JSP compiler and the bnd JSP analyzer plugin to use the same root. 
Maybe it was possible by another combination, by I could not see how. 

Thx.

Carlos.