### PR TITLE
LPS-121635 Compare upstream hash before fetching master-private from github-dev

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1105,9 +1105,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 		</condition>
 
 		<if>
-			<and>
-				<isset property="env.JENKINS_HOME" />
-			</and>
+			<isset property="env.JENKINS_HOME" />
 			<then>
 				<retry retrycount="5" retrydelay="3000">
 					<sequential>

--- a/build.xml
+++ b/build.xml
@@ -1121,8 +1121,8 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 							input="${github.git.ls.remote}"
 							override="true"
 							property="github.git.hash"
-							regexp="([0-9a-f]+).*"
-							replace="\1"
+							regexp="([0-9a-f]{7,40}).*"
+							select="\1"
 						/>
 
 						<exec executable="git" outputproperty="github.dev.git.ls.remote">
@@ -1135,8 +1135,8 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 							input="${github.dev.git.ls.remote}"
 							override="true"
 							property="github.dev.git.hash"
-							regexp="([0-9a-f]+).*"
-							replace="\1"
+							regexp="([0-9a-f]{7,40}).*"
+							select="\1"
 						/>
 
 						<condition else="git@github.com:liferay/liferay-portal-ee.git" property="profile.dxp.repository.url" value="git@github-dev.liferay.com:liferay/liferay-portal-ee.git">

--- a/build.xml
+++ b/build.xml
@@ -1113,10 +1113,42 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 					<sequential>
 						<delete failonerror="false" file="${user.home}/.ssh/known_hosts" />
 
+						<exec executable="git" outputproperty="github.git.ls.remote">
+							<arg value="ls-remote" />
+							<arg value="git@github.com:liferay/liferay-portal-ee.git" />
+							<arg value="${profile.dxp.branch.name}" />
+						</exec>
+
+						<propertyregex
+							input="${github.git.ls.remote}"
+							override="true"
+							property="github.git.hash"
+							regexp="([0-9a-f]+).*"
+							replace="\1"
+						/>
+
+						<exec executable="git" outputproperty="github.dev.git.ls.remote">
+							<arg value="ls-remote" />
+							<arg value="git@github-dev.liferay.com:liferay/liferay-portal-ee.git" />
+							<arg value="${profile.dxp.branch.name}" />
+						</exec>
+
+						<propertyregex
+							input="${github.dev.git.ls.remote}"
+							override="true"
+							property="github.dev.git.hash"
+							regexp="([0-9a-f]+).*"
+							replace="\1"
+						/>
+
+						<condition else="git@github.com:liferay/liferay-portal-ee.git" property="profile.dxp.repository.url" value="git@github-dev.liferay.com:liferay/liferay-portal-ee.git">
+							<equals arg1="${github.git.hash}" arg2="${github.dev.git.hash}" />
+						</condition>
+
 						<gradle-execute setupbinariescache="false" task="checkoutDXPScript">
 							<arg value="--build-file=${project.dir}/modules/profile-dxp.gradle" />
 							<arg value="-Dprofile.dxp.branch.name=${profile.dxp.branch.name}" />
-							<arg value="-Dprofile.dxp.repository.url=git@github-dev.liferay.com:liferay/liferay-portal-ee.git" />
+							<arg value="-Dprofile.dxp.repository.url=${profile.dxp.repository.url}" />
 						</gradle-execute>
 					</sequential>
 				</retry>

--- a/build.xml
+++ b/build.xml
@@ -1111,7 +1111,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 					<sequential>
 						<delete failonerror="false" file="${user.home}/.ssh/known_hosts" />
 
-						<exec executable="git" outputproperty="github.git.ls.remote">
+						<exec executable="git" falionerror="true" outputproperty="github.git.ls.remote">
 							<arg value="ls-remote" />
 							<arg value="git@github.com:liferay/liferay-portal-ee.git" />
 							<arg value="${profile.dxp.branch.name}" />

--- a/build.xml
+++ b/build.xml
@@ -1113,6 +1113,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 						<exec executable="git" falionerror="true" outputproperty="github.git.ls.remote">
 							<arg value="ls-remote" />
+							<arg value="-h" />
 							<arg value="git@github.com:liferay/liferay-portal-ee.git" />
 							<arg value="${profile.dxp.branch.name}" />
 						</exec>
@@ -1127,6 +1128,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 						<exec executable="git" outputproperty="github.dev.git.ls.remote">
 							<arg value="ls-remote" />
+							<arg value="-h" />
 							<arg value="git@github-dev.liferay.com:liferay/liferay-portal-ee.git" />
 							<arg value="${profile.dxp.branch.name}" />
 						</exec>

--- a/build.xml
+++ b/build.xml
@@ -1134,6 +1134,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 						</exec>
 
 						<propertyregex
+							defaultValue=""
 							input="${github.dev.git.ls.remote}"
 							override="true"
 							property="github.dev.git.hash"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-121635

CC: @yichenroy

Peter, I've made a few changes here to try to manage potential errors a little better but there's one more bit of logic that I think is needed. Specifically, github-dev.liferay.com is just a proxy for 16 different github-dev nodes that our code keeps in sync. This synchronization, however is not guaranteed. This means that the SHA that you get when you call

`git ls-remote git@github-dev.liferay.com master-private` is master-private's SHA on the github-dev node that you hit but when you clone the repo, you may or may not hit the same github-dev node. This means that there is a possibility that you will not get the SHA that you are expecting.

After some head scratching, I came up with what I think is a reasonable solution. 

When you call `checkoutDXPScript` you should set an optional property: `profile.dxp.branch.sha`. In your gradle script, you should check to see if the property exists. If it does exist, you can validate whether or not your new clone is at that SHA by calling `git rev-parse master-private`. If the SHA that is returned does not match `profile.dxp.branch.sha` then fail the task or redo the clone from github (or however you want to handle it). If you fail the task, the retry task in `build.xml` should detect the failure and retry (hopefully, the next try will not encounter the same problem). I would have implemented this myself but I'm not that familiar with gradle scripting so I thought I would send this pull request back to you with my proposal and see if you could add the changes.