### PR TITLE
LPS-167694 Add a new task to SF Gradle plugin for running SF code upgrades

### DIFF
--- a/modules/sdk/gradle-plugins-source-formatter/bnd.bnd
+++ b/modules/sdk/gradle-plugins-source-formatter/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: The Source Formatter Gradle plugin lets you format project files using the Liferay Source Formatter tool.
 Bundle-Name: Liferay Gradle Plugins Source Formatter
 Bundle-SymbolicName: com.liferay.gradle.plugins.source.formatter
-Bundle-Version: 5.1.165
+Bundle-Version: 5.2.0
 Export-Package: com.liferay.gradle.plugins.source.formatter
 -includeresource: @com.liferay.source.formatter-*.jar!/com/liferay/source/formatter/SourceFormatterArgs.class

--- a/modules/sdk/gradle-plugins-source-formatter/src/main/java/com/liferay/gradle/plugins/source/formatter/SourceFormatterPlugin.java
+++ b/modules/sdk/gradle-plugins-source-formatter/src/main/java/com/liferay/gradle/plugins/source/formatter/SourceFormatterPlugin.java
@@ -43,6 +43,8 @@ public class SourceFormatterPlugin implements Plugin<Project> {
 
 	public static final String FORMAT_SOURCE_TASK_NAME = "formatSource";
 
+	public static final String UPGRADE_SOURCE_TASK_NAME = "upgradeSource";
+
 	@Override
 	public void apply(Project project) {
 		Configuration sourceFormatterConfiguration =
@@ -50,6 +52,7 @@ public class SourceFormatterPlugin implements Plugin<Project> {
 
 		_addTaskCheckSourceFormatting(project);
 		_addTaskFormatSource(project);
+		_addTaskUpgradeSource(project);
 
 		_configureTasksFormatSource(project, sourceFormatterConfiguration);
 	}
@@ -106,6 +109,19 @@ public class SourceFormatterPlugin implements Plugin<Project> {
 		formatSourceTask.onlyIf(_skipIfExecutingParentTaskSpec);
 		formatSourceTask.setDescription(
 			"Runs Liferay Source Formatter to format the project files.");
+		formatSourceTask.setGroup("formatting");
+
+		return formatSourceTask;
+	}
+
+	private FormatSourceTask _addTaskUpgradeSource(Project project) {
+		FormatSourceTask formatSourceTask = GradleUtil.addTask(
+			project, UPGRADE_SOURCE_TASK_NAME, FormatSourceTask.class);
+
+		formatSourceTask.onlyIf(_skipIfExecutingParentTaskSpec);
+		formatSourceTask.setDescription(
+			"Runs Liferay Source Formatter to execute code upgrades.");
+		formatSourceTask.setCheckCategoryNames("Upgrade");
 		formatSourceTask.setGroup("formatting");
 
 		return formatSourceTask;

--- a/modules/sdk/gradle-plugins-source-formatter/src/main/resources/com/liferay/gradle/plugins/source/formatter/packageinfo
+++ b/modules/sdk/gradle-plugins-source-formatter/src/main/resources/com/liferay/gradle/plugins/source/formatter/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0


### PR DESCRIPTION
__Tickets:__
<https://issues.liferay.com/browse/LPS-165553>
<https://issues.liferay.com/browse/LPS-167694>

This pull request adds a new task to the `gradle-plugins-source-formatter` Gradle plugin to only run "Upgrade" SF checks. This should make running SF code upgrades easier to run. Let me know if there's something I'm missing or if I need to change anything.