### PR TITLE
LPS-173738 Upgrade sass-embedded-host version to 1.11.0

### DIFF
--- a/modules/util/sass-compiler-dart/build.gradle
+++ b/modules/util/sass-compiler-dart/build.gradle
@@ -2,8 +2,8 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.sass.compiler.api", version: "2.0.1"
 
 	compileInclude group: "com.google.protobuf", name: "protobuf-java", version: "3.21.7"
-	compileInclude group: "de.larsgrefer.sass", name: "sass-embedded-host", version: "1.0.1"
-	compileInclude group: "de.larsgrefer.sass", name: "sass-embedded-protocol", version: "1.0.1"
+	compileInclude group: "de.larsgrefer.sass", name: "sass-embedded-host", version: "1.11.0"
+	compileInclude group: "de.larsgrefer.sass", name: "sass-embedded-protocol", version: "1.11.0"
 }
 
 liferayOSGi {


### PR DESCRIPTION
Hi @petershin , the 2.x version of sass-embedded-host only support JDK17, so I upgradle it to 1.11.0 this time.
I have run the tests on my repo, the relevant test always failed, but it seems not related to my fix. https://github.com/Seiphon/liferay-portal/pull/63