### PR TITLE
LPS-176098 `NoClassDefFoundError` when running Source Formatter standalone JAR

### DIFF
--- a/modules/util/source-formatter-standalone/build.gradle
+++ b/modules/util/source-formatter-standalone/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
+	compileInclude group: "antlr", name: "antlr", version: "2.7.7"
 	compileInclude group: "com.googlecode.java-diff-utils", name: "diffutils", version: "1.3.0"
 	compileInclude group: "com.puppycrawl.tools", name: "checkstyle", version: "8.29"
 	compileInclude group: "com.thoughtworks.qdox", name: "qdox", version: "2.0-M5"
+	compileInclude group: "commons-beanutils", name: "commons-beanutils", version: "1.9.4"
+	compileInclude group: "commons-collections", name: "commons-collections", version: "3.2.2"
 	compileInclude group: "commons-io", name: "commons-io", version: "2.11.0"
 	compileInclude group: "commons-logging", name: "commons-logging", version: "1.2"
 	compileInclude(group: "jaxen", name: "jaxen", version: "1.1.1") {


### PR DESCRIPTION
Ticket: [LPS-176098](https://issues.liferay.com/browse/LPS-176098)

The `source-formatter-standalone` fat JAR throws `NoClassDefFoundError` exceptions during runtime due to missing transitive dependencies. Specifically, the issue occurs when linting/formatting Java code. I am sending this pull request to you just to make sure I am fixing this issue correctly.

Let me know if you have any questions.