### PR TITLE
LPS-142725 Fix XXE vulnerability in JavadocFormatter._getSAXReader

### DIFF
--- a/modules/util/javadoc-formatter/src/main/java/com/liferay/javadoc/formatter/JavadocFormatter.java
+++ b/modules/util/javadoc-formatter/src/main/java/com/liferay/javadoc/formatter/JavadocFormatter.java
@@ -1856,7 +1856,7 @@ public class JavadocFormatter {
 	}
 
 	private SAXReader _getSAXReader() {
-		return SAXReaderFactory.getSAXReader(null, false, false);
+		return SAXReaderFactory.getSAXReader(null, false, true);
 	}
 
 	private String _getSpacesIndent(int length) {


### PR DESCRIPTION
The SAXReader returned by JavadocFormatter._getSAXReader will automatically load and replace any DTD entity references in the XML, including references to external files, so we can set 'security' parameter as 'true'