### PR TITLE
LPS-142789 XXE vulnerability in TLDFormatter._getSAXReader

### DIFF
--- a/modules/util/tld-formatter/src/main/java/com/liferay/tld/formatter/TLDFormatter.java
+++ b/modules/util/tld-formatter/src/main/java/com/liferay/tld/formatter/TLDFormatter.java
@@ -161,7 +161,7 @@ public class TLDFormatter {
 	}
 
 	private SAXReader _getSAXReader() {
-		return SAXReaderFactory.getSAXReader(null, false, false);
+		return SAXReaderFactory.getSAXReader(null, false, true);
 	}
 
 	private void _sortElements(


### PR DESCRIPTION
On the description of https://issues.liferay.com/browse/LPS-142789, the SAXReader returned by TLDFormatter._getSAXReader will automatically load and replace any DTD entity references in the XML, including references to external files. So we can change `SAXReaderFactory.getSAXReader(null, false, false);` to `SAXReaderFactory.getSAXReader(null, false, true);`