### PR TITLE
LRCI-3496 set autoRemove to true and then we can avoid depending on removeDockerContainer

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/RootProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/RootProjectConfigurator.java
@@ -570,8 +570,7 @@ public class RootProjectConfigurator implements Plugin<Project> {
 			project, CREATE_DOCKER_CONTAINER_TASK_NAME,
 			DockerCreateContainer.class);
 
-		dockerCreateContainer.dependsOn(
-			verifyProductTask, dockerBuildImage, dockerRemoveContainer);
+		dockerCreateContainer.dependsOn(verifyProductTask, dockerBuildImage);
 		dockerCreateContainer.mustRunAfter(
 			verifyProductTask, dockerRemoveContainer);
 
@@ -605,6 +604,10 @@ public class RootProjectConfigurator implements Plugin<Project> {
 
 		DockerCreateContainer.HostConfig hostConfig =
 			dockerCreateContainer.getHostConfig();
+
+		Property<Boolean> autoRemove = hostConfig.getAutoRemove();
+
+		autoRemove.set(true);
 
 		MapProperty<String, String> binds = hostConfig.getBinds();
 


### PR DESCRIPTION
cc @drewbrokke @simonjhy Hey guys, I wanted to update how createDockerContainer task works.  I don't think it should depend on `removeDockerContainer` and that prevents us from doing things like this
```
runPoshi {
    dependsOn ":startDockerContainer"
    finalizedBy ":stopDockerContainer"
}
```

Instead I think setting "autoRemove = true" is better, than the liferay container will be removed automatically after it stops.  If someone wants to keep the container around (to restart it or save off a layer) they can do this in their build.gradle

```
createDockerContainer {
    hostConfig.autoRemove = false
}
```