### PR TITLE
LPS-183286 Every fromTask statement executes from every client-extension.yaml file on any of the deploy tasks

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionProfiles/client-extension/client-extension.emptyassemble.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionProfiles/client-extension/client-extension.emptyassemble.yaml
@@ -1,0 +1,1 @@
+assemble:

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -158,9 +158,11 @@ public class ClientExtensionProjectConfigurator
 					JsonNode fieldJsonNode = entry.getValue();
 
 					if (Objects.equals(fieldName, "assemble")) {
-						_configureAssembleClientExtensionTask(
-							project, assembleClientExtensionTaskProvider,
-							(ArrayNode)fieldJsonNode, profileName);
+						if (!fieldJsonNode.isNull()) {
+							_configureAssembleClientExtensionTask(
+								project, assembleClientExtensionTaskProvider,
+								(ArrayNode)fieldJsonNode, profileName);
+						}
 
 						return;
 					}


### PR DESCRIPTION
This is an update for [LPS-183286](https://issues.liferay.com/browse/LPS-183286).

This is a quick fix for an edge case where `assemble:` in the yaml file is expected to have no items.