### PR TITLE
LPS-206114 Add missing format tooling files

### DIFF
--- a/modules/.eslintignore
+++ b/modules/.eslintignore
@@ -43,6 +43,15 @@
     testIntegration/**
 
 ##
+## Playwright Tests
+##
+
+    #
+    # Tests have their own formatting rules.
+    #
+    /test/playwright/**
+
+##
 ## Third-Party
 ##
 

--- a/modules/test/playwright/.eslintignore
+++ b/modules/test/playwright/.eslintignore
@@ -1,0 +1,1 @@
+node_modules/**

--- a/modules/test/playwright/.eslintrc.js
+++ b/modules/test/playwright/.eslintrc.js
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const path = require('path');
+
+/**
+ * We use @liferay/npm-scripts to perform linting in a controlled way, but we
+ * also try to expose its configuration here so it can be picked up by editors.
+ */
+let config = {};
+
+try {
+	config = require('@liferay/npm-scripts/src/config/eslint.config');
+}
+catch (error) {
+	throw new Error('@liferay/npm-scripts is not installed; please run "yarn"');
+}
+
+config = {
+	...config,
+	env: {
+		browser: true,
+		es6: true,
+		node: true,
+	},
+	globals: {
+		...config.globals,
+		MODULE_PATH: true,
+		configuration: true,
+		fragmentElement: true,
+		fragmentNamespace: true,
+		layoutMode: true,
+	},
+	overrides: [
+		{
+			files: [
+				'liferay-sample-workspace/client-extensions/liferay-sample-custom-element-*/**',
+			],
+			rules: {
+				'@liferay/no-abbreviations': 'off',
+				'@liferay/no-it-should': 'off',
+				'sort-keys': 'off',
+			},
+		},
+	],
+	rules: {
+		'@liferay/empty-line-between-elements': 'off',
+		'@liferay/import-extensions': 'off',
+		'@liferay/portal/deprecation': 'off',
+		'@liferay/portal/no-document-cookie': 'off',
+		'@liferay/portal/no-explicit-extend': 'off',
+		'@liferay/portal/no-global-fetch': 'off',
+		'@liferay/portal/no-global-storage': 'off',
+		'@liferay/portal/no-loader-import-specifier': 'off',
+		'@liferay/portal/no-localhost-reference': 'off',
+		'@liferay/portal/no-react-dom-create-portal': 'off',
+		'@liferay/portal/no-react-dom-render': 'off',
+		'@liferay/portal/no-side-navigation': 'off',
+		'@liferay/portal/unexecuted-ismounted': 'off',
+		'no-empty': ['error', {allowEmptyCatch: true}],
+		'notice/notice': [
+			'error',
+			{
+				nonMatchingTolerance: 0.7,
+				onNonMatchingHeader: 'replace',
+				templateFile: path.join(__dirname, 'copyright.js'),
+			},
+		],
+	},
+};
+
+module.exports = config;

--- a/modules/test/playwright/.stylelintrc.js
+++ b/modules/test/playwright/.stylelintrc.js
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/**
+ * We use @liferay/npm-scripts to perform linting in a controlled way, but we
+ * also try to expose its configuration here so it can be picked up by editors.
+ */
+let config = {};
+
+try {
+	config = require('@liferay/npm-scripts/src/config/stylelint.json');
+}
+catch (error) {
+	throw new Error('@liferay/npm-scripts is not installed; please run "yarn"');
+}
+
+module.exports = {
+	...config,
+	rules: {
+		...config.rules,
+		'liferay/no-block-comments': false,
+		'selector-type-no-unknown': [
+			true,
+			{
+				ignore: 'custom-elements',
+			},
+		],
+	},
+};

--- a/modules/test/playwright/copyright.js
+++ b/modules/test/playwright/copyright.js
@@ -1,0 +1,4 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */

--- a/modules/test/playwright/package.json
+++ b/modules/test/playwright/package.json
@@ -17,8 +17,8 @@
 		"prettier": "2.1.2"
 	},
 	"scripts": {
-		"checkFormat": "liferay-npm-scripts prettier \"**/*.ts\" --list-different",
-		"format": "liferay-npm-scripts prettier \"**/*.ts\" --write",
+		"checkFormat": "liferay-npm-scripts lint && liferay-npm-scripts format:check",
+		"format": "liferay-npm-scripts lint:fix && liferay-npm-scripts format",
 		"playwright": "playwright",
 		"test": "playwright test"
 	},


### PR DESCRIPTION
These files are needed so that:

  1. The standard portal SF doesn't try to format playwright files.
  2. Playwright's SF has a meaningful set of rules to begin with