### PR TITLE
LRCI-4269 Set higher memory settings for gradle execution when configured

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1971,6 +1971,13 @@ rerun your task.
 				</then>
 			</if>
 
+			<if>
+				<isset property="org.gradle.jvmargs[${gradle.server.memory}]" />
+				<then>
+					<propertycopy from="org.gradle.jvmargs[${gradle.server.memory}]" name="org.gradle.jvmargs" override="true" />
+				</then>
+			</if>
+
 			<echoproperties destfile="${gradle.properties.file}">
 				<propertyset>
 					<propertyref name="app.server.type" />

--- a/build.properties
+++ b/build.properties
@@ -432,6 +432,9 @@
     gradle.releng.pom.scm.developerConnection=scm:git:git@github.com:liferay/liferay-portal.git
     gradle.releng.pom.scm.url=https://github.com/liferay/liferay-portal
 
+    gradle.server.memory=12gb
+    #gradle.server.memory=24gb
+
     gradle.stop.daemon.enabled=true
 
     #gradle.update.file.versions.excludes=**/gradle-plugins-target-platform/,**/gradle-plugins-workspace/
@@ -441,6 +444,7 @@
     org.gradle.daemon=true
     org.gradle.internal.launcher.welcomeMessageEnabled=false
     org.gradle.jvmargs=-Xms8g -Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=512m -XX:MaxNewSize=2g -XX:MetaspaceSize=512m -XX:NewSize=2g -XX:SurvivorRatio=14 -XX:TargetSurvivorRatio=14
+    org.gradle.jvmargs[24gb]=-Xms16g -Xmx16g -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize=512m -XX:MaxNewSize=2g -XX:MetaspaceSize=512m -XX:NewSize=2g -XX:SurvivorRatio=14 -XX:TargetSurvivorRatio=14
     org.gradle.logging.level=lifecycle
     org.gradle.warning.mode=none
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-4269

@petershin - I'm not sure if this is the right way to handle this, but in CI I can set this value:

`build.[hostname].properties`
```
gradle.server.memory=24gb
```
After making these updates I saw that this particular memory increase was displayed:
https://develocity.liferay.com/s/duakf7vgclyuu/performance/build#memory-ps-old-gen

I'm not sure how to change those other values.
https://develocity.liferay.com/s/duakf7vgclyuu/performance/build#memory-ps-eden-space
https://develocity.liferay.com/s/duakf7vgclyuu/performance/build#memory-ps-survivor-space

So, this is based on what Gradle was saying about increasing the memory to potentially see performance gains.